### PR TITLE
chore(mise): upgrade dependencies

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -11,7 +11,7 @@ TALOS_DIR = "{{config_root}}/talos"
 
 [tools]
 "python" = "3.13"
-"pipx:makejinja" = "2.7.2"
+"pipx:makejinja" = "2.8.0"
 "aqua:budimanjojo/talhelper" = "3.0.29"
 "aqua:cilium/cilium-cli" = "0.18.4"
 "aqua:cli/cli" = "2.74.1"


### PR DESCRIPTION
Upgraded dependencies found in `.mise.toml`:

```diff
diff --git a/.mise.toml b/.mise.toml
index 5def8a1..c79ef92 100644
--- a/.mise.toml
+++ b/.mise.toml
@@ -11,7 +11,7 @@ TALOS_DIR = "{{config_root}}/talos"
 
 [tools]
 "python" = "3.13"
-"pipx:makejinja" = "2.7.2"
+"pipx:makejinja" = "2.8.0"
 "aqua:budimanjojo/talhelper" = "3.0.29"
 "aqua:cilium/cilium-cli" = "0.18.4"
 "aqua:cli/cli" = "2.74.1"
```

> [!TIP]
> Merge this pull request and then run `mise upgrade --bump` on your workstation.