### PR TITLE
feat(tetragon): add 3 new TracingPolicies + enable cgidmap

### DIFF
--- a/kubernetes/apps/kube-system/tetragon/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/tetragon/app/helmrelease.yaml
@@ -92,6 +92,12 @@ spec:
       cri:
         enabled: true
         socketHostPath: /run/containerd/containerd.sock
+      # cgidmap uses cgroup IDs for pod association (v1.7+). Required on Talos
+      # cgroupv2 — without it the agent logs 'failed to find cgroup id.
+      # Skipping container' warnings and drops container enrichment on events.
+      # Depends on cri.enabled=true (above).
+      cgidmap:
+        enabled: true
       prometheus:
         enabled: true
         port: 2112

--- a/kubernetes/apps/kube-system/tetragon/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/tetragon/app/kustomization.yaml
@@ -8,3 +8,6 @@ resources:
   - ./tracingpolicy-sensitive-files.yaml
   - ./tracingpolicy-network-egress.yaml
   - ./tracingpolicy-privilege-escalation.yaml
+  - ./tracingpolicy-kernel-integrity.yaml
+  - ./tracingpolicy-container-escape.yaml
+  - ./tracingpolicy-package-manager-exec.yaml

--- a/kubernetes/apps/kube-system/tetragon/app/tracingpolicy-container-escape.yaml
+++ b/kubernetes/apps/kube-system/tetragon/app/tracingpolicy-container-escape.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cilium/tetragon/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+# Container-escape primitives. Not scoped to workload namespaces via
+# TracingPolicyNamespaced because container-runtime components (runc,
+# containerd-shim, kubelet) legitimately call these in kube-system — we
+# exclude them via matchBinaries NotIn and let every other namespace
+# trigger.
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: monitor-container-escape
+  namespace: kube-system
+spec:
+  kprobes:
+    # Mount syscall inside containers. Workload pods should never call mount(2).
+    # Container runtimes use it at container creation; exclude their binaries.
+    - call: "__x64_sys_mount"
+      syscall: true
+      selectors:
+        - matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/bin/containerd"
+                - "/usr/bin/containerd-shim-runc-v2"
+                - "/usr/bin/crun"
+                - "/usr/local/bin/kubelet"
+                - "/usr/bin/kubelet"
+                - "/usr/bin/mount"
+                - "/bin/mount"
+          matchActions:
+            - action: Post
+    # pivot_root(2). Near-zero false positive outside runtime startup.
+    - call: "__x64_sys_pivot_root"
+      syscall: true
+      selectors:
+        - matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/runc"
+                - "/usr/bin/containerd"
+                - "/usr/bin/containerd-shim-runc-v2"
+                - "/usr/bin/crun"
+          matchActions:
+            - action: Post
+    # ptrace(2). Debuggers inside running containers (gdb, strace attach) are
+    # suspicious in prod workloads. Extend matchBinaries NotIn as known-legit
+    # tools are identified.
+    - call: "__x64_sys_ptrace"
+      syscall: true
+      args:
+        - index: 0
+          type: "int64"
+      selectors:
+        - matchActions:
+            - action: Post

--- a/kubernetes/apps/kube-system/tetragon/app/tracingpolicy-kernel-integrity.yaml
+++ b/kubernetes/apps/kube-system/tetragon/app/tracingpolicy-kernel-integrity.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cilium/tetragon/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+# Talos runs a locked, signed kernel. Any module load or BPF program load from
+# a workload pod is anomalous. Tetragon and Cilium legitimately load BPF; we
+# exclude them via matchBinaries NotIn.
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: monitor-kernel-integrity
+  namespace: kube-system
+spec:
+  kprobes:
+    # Kernel module load attempts. On Talos these should never succeed (kernel
+    # is locked), but the attempt itself is high-signal.
+    - call: "security_kernel_module_request"
+      syscall: false
+      args:
+        - index: 0
+          type: "string"
+      selectors:
+        - matchActions:
+            - action: Post
+    # User-space bpf() syscall. Legitimate consumers (Cilium agent, Tetragon
+    # itself) are on the NotIn allowlist. Anything else invoking bpf() is
+    # a strong signal — cryptominer, rootkit, kernel-exploit, or CVE probe.
+    - call: "__x64_sys_bpf"
+      syscall: true
+      args:
+        - index: 0
+          type: "int"
+      selectors:
+        - matchBinaries:
+            - operator: "NotIn"
+              values:
+                - "/usr/bin/tetragon"
+                - "/usr/bin/cilium-agent"
+                - "/usr/bin/cilium-operator-generic"
+                - "/usr/bin/cilium-health-responder"
+                - "/usr/bin/cilium-envoy"
+                - "/usr/local/bin/tetragon"
+                - "/usr/bin/runc"
+                - "/usr/bin/containerd"
+          matchActions:
+            - action: Post

--- a/kubernetes/apps/kube-system/tetragon/app/tracingpolicy-package-manager-exec.yaml
+++ b/kubernetes/apps/kube-system/tetragon/app/tracingpolicy-package-manager-exec.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cilium/tetragon/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+# Runtime package installs inside running containers. Our images bake deps
+# at build; an in-container apt/pip/npm at runtime = drift, supply-chain
+# attack, or backdoor staging.
+#
+# Intentionally does not flag llama-swap model-fetch (uses curl, not a pkg mgr).
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: monitor-package-manager-exec
+  namespace: kube-system
+spec:
+  kprobes:
+    - call: "security_bprm_check"
+      syscall: false
+      args:
+        - index: 0
+          type: "linux_binprm"
+      selectors:
+        - matchArgs:
+            - index: 0
+              operator: "Postfix"
+              values:
+                - "/apt"
+                - "/apt-get"
+                - "/dpkg"
+                - "/dnf"
+                - "/yum"
+                - "/rpm"
+                - "/apk"
+                - "/pip"
+                - "/pip3"
+                - "/npm"
+                - "/yarn"
+                - "/pnpm"
+                - "/gem"
+                - "/cargo"
+                - "/go"
+          matchActions:
+            - action: Post


### PR DESCRIPTION
Chart 1.7.0 is now live, unlocking the full set of selectors and cgroup-id enrichment. Four orthogonal changes:

- Add `monitor-kernel-integrity` (cluster-scoped). Hooks security_kernel_module_request and __x64_sys_bpf. Catches kernel-module load attempts (Talos locked kernel means any attempt is anomalous) and user-space bpf() syscalls from non-Cilium/non-Tetragon binaries — which is what a cryptominer, rootkit, or CVE probe typically triggers. MITRE T1547.006, T1106.

- Add `monitor-container-escape` (cluster-scoped). Hooks sys_mount, sys_pivot_root, sys_ptrace with matchBinaries NotIn for the container runtime. Workload pods should never call these; container runtimes use them only at pod creation. MITRE T1611, T1055.008.

- Add `monitor-package-manager-exec` (cluster-scoped). Hooks security_bprm_check with Postfix match on common package manager binaries (apt, dnf, apk, pip, npm, yarn, gem, cargo, go). Our images bake deps at build; runtime install = drift, backdoor staging, or supply-chain attack.

- Enable cgidmap on tetragon values (v1.7+ feature). Eliminates the 'failed to find cgroup id. Skipping container' warnings observed in agent logs on Talos cgroupv2. Container enrichment on events now works consistently.

All new policies start with action Post (monitor-only). After a baseline period we can flip specific triggers to Signal/Sigkill if desired. matchBinaries NotIn allowlists are initial best-guess — extend as baselines reveal legit consumers.

Refs: home-ops-coi, home-ops-619, home-ops-2zi, home-ops-5e4, home-ops-y5m