### PR TITLE
feat(tetragon): cluster-specific policies for HA pivot + dolt exec

### DIFF
--- a/kubernetes/apps/databases/dolt/app/kustomization.yaml
+++ b/kubernetes/apps/databases/dolt/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./helmrelease.yaml
   - ./tcproute.yaml
   - ./httproute.yaml
+  - ./tracingpolicy-dolt-exec.yaml

--- a/kubernetes/apps/databases/dolt/app/tracingpolicy-dolt-exec.yaml
+++ b/kubernetes/apps/databases/dolt/app/tracingpolicy-dolt-exec.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cilium/tetragon/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+# Dolt is externally exposed on dolt.68cc.io:3306 via Traefik TCP passthrough
+# with DOLT_ROOT_HOST='%' (root reachable from any source IP). CrowdSec does
+# not inspect raw TCP, so there is no ingress bot-protection layer for Dolt.
+#
+# dolt-sql-server never spawns child processes in steady-state operation.
+# ANY exec inside the dolt pod is a strong signal of compromise: SQL-layer
+# RCE (LOAD DATA INFILE + write primitives, dolt_procedures misuse),
+# attacker-dropped binary execution, or in-band shell escape.
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicyNamespaced
+metadata:
+  name: monitor-dolt-exec
+  namespace: databases
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: dolt
+  kprobes:
+    - call: "security_bprm_check"
+      syscall: false
+      args:
+        - index: 0
+          type: "linux_binprm"
+      selectors:
+        - matchActions:
+            - action: Post

--- a/kubernetes/apps/kube-system/tetragon/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/tetragon/app/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./tracingpolicy-container-escape.yaml
   - ./tracingpolicy-package-manager-exec.yaml
   - ./tracingpolicy-shell-spawn.yaml
+  - ./tracingpolicy-ha-pivot.yaml

--- a/kubernetes/apps/kube-system/tetragon/app/tracingpolicy-ha-pivot.yaml
+++ b/kubernetes/apps/kube-system/tetragon/app/tracingpolicy-ha-pivot.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cilium/tetragon/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
+# Home Assistant admin-auth bypass via pod-CIDR trust.
+# HA helmrelease sets allow_bypass_login for 10.42.0.0/16. Any compromised
+# pod in the cluster auto-authenticates to HA as admin. High-value pivot
+# target.
+#
+# Detection: post tcp_connect events targeting the HA ClusterIP
+# (10.43.143.160:8123). podSelector excludes known-legit consumers (homepage
+# widget + HA pod itself). Every other caller is a pivot attempt by
+# definition — HA runs hostNetwork, so in-cluster access to the svc exists
+# only for dashboard widgets.
+#
+# ClusterIP hardcoded here; a ClusterIP rotation would require updating this
+# policy. Trade-off for simplicity over dynamic lookup.
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: monitor-ha-pivot
+  namespace: kube-system
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: NotIn
+        values:
+          - home-assistant
+          - homepage
+  kprobes:
+    - call: "tcp_connect"
+      syscall: false
+      args:
+        - index: 0
+          type: "sock"
+      selectors:
+        - matchArgs:
+            - index: 0
+              operator: "DAddr"
+              values:
+                - "10.43.143.160/32"
+            - index: 0
+              operator: "DPort"
+              values:
+                - "8123"
+          matchActions:
+            - action: Post


### PR DESCRIPTION
Two targeted TracingPolicies against concrete cluster threat surface identified in the Tetragon audit (home-ops-y5m). Both action: Post monitor-only on initial rollout.

monitor-ha-pivot (cluster-wide TracingPolicy):
  Home Assistant helmrelease sets `allow_bypass_login` for the 10.42.0.0/16
  pod CIDR, which means any compromised pod in the cluster auto-authenticates
  to HA as admin. HA runs hostNetwork:true, so in-cluster access to its
  ClusterIP (10.43.143.160:8123) exists only for the homepage widget.
  Any other pod hitting that ClusterIP is a pivot attempt by definition.
  podSelector NotIn [home-assistant, homepage] excludes legit consumers;
  DAddr + DPort selectors pin the target.

monitor-dolt-exec (TracingPolicyNamespaced in databases):
  Dolt is externally exposed on dolt.68cc.io:3306 via Traefik TCP passthrough
  with DOLT_ROOT_HOST='%'. CrowdSec does not inspect raw TCP. dolt-sql-server
  never spawns child processes in steady-state; any exec inside the dolt pod
  is a strong signal of compromise (SQL-layer RCE, in-band shell escape,
  attacker-dropped binary execution). Hook: security_bprm_check (LSM) with
  no matchArgs filter — every exec is posted.

Deferred from this PR (separate issues):
  - monitor-homebridge-egress — needs LAN/IoT subnet baseline before scoping the NotDAddr exclude list.
  - monitor-llama-models-write — needs init-container pid capture strategy; current security_file_permission hook design is too noisy without it.
  - monitor-postgres-external-ingress — inet_csk_accept sees Traefik pod IP (in pod CIDR) as source, not original client. Requires a different hook or Cilium NetworkPolicy approach; not a fit for Tetragon alone.

Refs: home-ops-m2g, home-ops-y5m