### PR TITLE
feat(tetragon): migrate gRPC to unix socket + drop redundant image ov…

### DIFF
--- a/kubernetes/apps/kube-system/tetragon/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/tetragon/app/helmrelease.yaml
@@ -57,9 +57,9 @@ spec:
           enabled: true
     tetragon:
       enabled: true
-      image:
-        repository: quay.io/cilium/tetragon
-        tag: v1.7.0
+      # image override removed — chart 1.7.0 ships appVersion 1.7.0 so the
+      # default image (quay.io/cilium/tetragon:v1.7.0) already matches. Chart
+      # bumps track image bumps automatically.
       resources:
         requests:
           cpu: 10m
@@ -88,7 +88,12 @@ spec:
       enableProcessNs: true
       grpc:
         enabled: true
-        address: "localhost:54321"
+        # address override removed — chart 1.7.0 default is
+        # unix:///var/run/tetragon/tetragon.sock (breaking change from 1.6
+        # localhost:54321). Chart mounts /var/run/tetragon as a host-path
+        # volume on every node via the tetragon-run volume (see chart
+        # daemonset.yaml), so the socket is reachable from the node and from
+        # tetra CLI via kubectl exec.
       cri:
         enabled: true
         socketHostPath: /run/containerd/containerd.sock


### PR DESCRIPTION
…erride

Two config-hygiene fixes now that chart 1.7.0 is live:

- Drop `tetragon.image` override block. Chart 1.7.0 ships appVersion 1.7.0 and defaults to quay.io/cilium/tetragon:v1.7.0 — the override was a no-op. Dropping it lets chart bumps auto-track image bumps instead of requiring manual edits to both tag and chart version.

- Drop `tetragon.grpc.address: localhost:54321` override. Chart 1.7.0 flipped the default to unix:///var/run/tetragon/tetragon.sock (breaking change from 1.6.x). Our override was forcing the old tcp listener. Removing it activates the unix socket; chart already mounts /var/run/tetragon as a host-path volume via the tetragon-run volume in its daemonset template, so the socket appears on every node for tetra CLI access.

Unblocks home-ops-pcr (tetra CLI runbook).

Refs: home-ops-8yt, home-ops-y5m