### PR TITLE
feat(dolt): add Velero pre/post backup hooks for SQL dumps

### DIFF
--- a/kubernetes/apps/databases/dolt/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/dolt/app/helmrelease.yaml
@@ -20,6 +20,23 @@ spec:
     global:
       annotations:
         reloader.stakater.com/auto: "true"
+    defaultPodOptions:
+      annotations:
+        # Velero backup hooks: write per-database dolt SQL dumps to
+        # /var/lib/dolt/backup/<db>.sql before kopia fs-backup captures
+        # the PVC, then clean up after the backup completes.
+        # Restore path: kopia restores the raw dolt chunk store *and*
+        # the portable SQL dumps, so recovery can use either one.
+        # Each db subdir under /var/lib/dolt is its own dolt repository;
+        # `dolt dump -fn` only works from inside a repo, hence the loop.
+        pre.hook.backup.velero.io/command: |
+          ["sh","-c","rm -rf /var/lib/dolt/backup && mkdir -p /var/lib/dolt/backup && for db in $(ls -d /var/lib/dolt/*/ | xargs -n1 basename | grep -v '^backup$'); do cd /var/lib/dolt/$db && dolt dump -f -fn /var/lib/dolt/backup/$db.sql; done"]
+        pre.hook.backup.velero.io/timeout: 5m
+        pre.hook.backup.velero.io/container: app
+        post.hook.backup.velero.io/command: |
+          ["sh","-c","rm -rf /var/lib/dolt/backup"]
+        post.hook.backup.velero.io/timeout: 1m
+        post.hook.backup.velero.io/container: app
     controllers:
       dolt:
         containers:


### PR DESCRIPTION
Dolt PVC is already captured by the existing velero daily-backup Schedule (kopia fs-backup), but the hot chunk store is copied file-by-file and can be mid-write. Add velero pod hook annotations so each backup cycle:

  1. Pre-hook dumps every dolt database under /var/lib/dolt/<db> to a SQL file under /var/lib/dolt/backup/<db>.sql
  2. Velero kopia captures the PVC including those portable dumps
  3. Post-hook removes the dump dir

Restore options: kopia restores the raw chunk store, and the SQL dumps live alongside for portable re-import if the chunk store is damaged or the dolt version has changed. No new CronJob, no new secret, no rustfs-specific tooling — rides the same velero pipe.

closes home-ops-yz3