### PR TITLE
fix(tetragon): drop exportFilename override so sidecar re-emits to VL

### DIFF
--- a/kubernetes/apps/kube-system/tetragon/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/tetragon/app/helmrelease.yaml
@@ -70,8 +70,13 @@ spec:
       securityContext:
         privileged: true
       processCacheSize: 65536
-      exportFilename: /dev/stdout
-      exportRateLimit: 1000
+      # exportFilename + exportRateLimit overrides removed — chart defaults
+      # (exportDirectory=/var/run/cilium/tetragon, exportFilename=tetragon.log,
+      # exportRateLimit=-1 unlimited) write structured events to a file that
+      # the export-stdout sidecar tails. Sidecar re-emits to pod stdout,
+      # Vector captures via /var/log/containers, ships to VictoriaLogs. The
+      # prior /dev/stdout override made the agent bypass the file, leaving
+      # the sidecar dry and PROCESS_* events invisible to VL.
       # Event filtering - exclude platform namespaces, focus on workloads.
       # databases intentionally NOT in denyList (want dolt/postgres exec visibility).
       exportAllowList: |-


### PR DESCRIPTION
Current config set `exportFilename: /dev/stdout` on the agent, which bypasses the chart's export-stdout sidecar. That sidecar is deployed to tail the file `/var/run/cilium/tetragon/tetragon.log` and re-emit it to pod stdout for log-shipper capture. Our override made the agent skip the file entirely, so the sidecar ran forever with nothing to tail. Result: agent operational warnings reached VictoriaLogs via Vector (captured from the tetragon container's own stdout), but PROCESS_EXEC / PROCESS_KPROBE / PROCESS_LSM structured events never reached VL — defeating the purpose of every monitor-only Post policy for forensics.

Drop `exportFilename` + `exportRateLimit` overrides. Chart defaults are `exportFilename: tetragon.log` in `exportDirectory: /var/run/cilium/tetragon` with unlimited rate. With defaults:
  agent → /var/run/cilium/tetragon/tetragon.log (rotating, 10MB x 5)
  export-stdout sidecar tails file → pod stdout
  Vector captures /var/log/containers/*.log → VictoriaLogs
  LogsQL query: kubernetes.container_name:=export-stdout "process_kprobe"

Refs: home-ops-clc, home-ops-y5m