### PR TITLE
fix(tetragon): drop noisy security_kernel_module_request hook

### DIFF
--- a/kubernetes/apps/kube-system/tetragon/app/tracingpolicy-kernel-integrity.yaml
+++ b/kubernetes/apps/kube-system/tetragon/app/tracingpolicy-kernel-integrity.yaml
@@ -1,8 +1,13 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/cilium/tetragon/main/pkg/k8s/apis/cilium.io/client/crds/v1alpha1/cilium.io_tracingpolicies.yaml
-# Talos runs a locked, signed kernel. Any module load or BPF program load from
-# a workload pod is anomalous. Tetragon and Cilium legitimately load BPF; we
-# exclude them via matchBinaries NotIn.
+# Talos runs a locked, signed kernel. BPF program load from a workload pod is
+# anomalous — Tetragon and Cilium legitimately load BPF; we exclude them via
+# matchBinaries NotIn.
+#
+# security_kernel_module_request was removed (home-ops-jsl). It fired ~62/hour
+# from legit userspace-driven module auto-loads (netfilter/iptables,
+# filesystem drivers, protocol handlers) — all BLOCKED by Talos at load time,
+# but the request callback still fires. Zero actionable signal.
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
 metadata:
@@ -10,16 +15,6 @@ metadata:
   namespace: kube-system
 spec:
   kprobes:
-    # Kernel module load attempts. On Talos these should never succeed (kernel
-    # is locked), but the attempt itself is high-signal.
-    - call: "security_kernel_module_request"
-      syscall: false
-      args:
-        - index: 0
-          type: "string"
-      selectors:
-        - matchActions:
-            - action: Post
     # User-space bpf() syscall. Legitimate consumers (Cilium agent, Tetragon
     # itself) are on the NotIn allowlist. Anything else invoking bpf() is
     # a strong signal — cryptominer, rootkit, kernel-exploit, or CVE probe.


### PR DESCRIPTION
TetragonKernelModuleLoadAttempt alert has been firing constantly (1192 events in 24h cluster-wide, ~62/hour sustained). Investigation:

- Counter `tetragon_policy_events_total{policy="monitor-kernel-integrity"}` attributable to hook `kprobe:security_kernel_module_request` only; sibling `__x64_sys_bpf` hook is silent (0 events), so the bpf() allowlist is working perfectly.
- security_kernel_module_request fires on legit kernel-driven auto-loads (netfilter/iptables modules, filesystem drivers, protocol handlers) initiated by Talos userspace during normal operation. The kernel BLOCKS the actual load (Talos ships with a locked, signed kernel), but the REQUEST callback still executes.
- Alert label grouping (namespace, pod, workload) ends up empty because the caller is a host-level binary; AM deduplication fails.
- Zero actionable signal: every event is noise, not a compromise indicator.

Drop the security_kernel_module_request kprobe block from the policy. Keep __x64_sys_bpf — real supply-chain / rootkit signal with near-zero false-positive rate.

The TetragonKernelModuleLoadAttempt alert rule in prometheusrule.yaml keeps the same expression; counter rate will drop to zero once the policy reload takes effect, alert goes inactive.

Refs: home-ops-jsl, home-ops-y5m