### PR TITLE
feat(databases): expanded alerts + grafana dashboards + tuning recommendations

### DIFF
--- a/docs/runbooks/database-tuning-recommendations.md
+++ b/docs/runbooks/database-tuning-recommendations.md
@@ -1,0 +1,209 @@
+# Database Tuning Recommendations (post-AI-adoption)
+
+**Audit date:** 2026-05-21
+**Scope:** CloudNativePG `postgres17` cluster (databases ns) + DragonflyDB `dragonflydb` instance (databases ns).
+**Companion PR (this branch):** monitoring (alerts + dashboards).
+**Companion PR (planned, not yet authored):** performance tuning (the items in this doc).
+
+This doc captures the audit findings + the changes deferred to PR 2. Apply during a low-traffic window — PG parameter changes restart pods one at a time (rolling update with quorum gating); dragonfly resource bumps cause a brief restart.
+
+---
+
+## CloudNativePG findings
+
+### Live state (probed 2026-05-21)
+
+- Operator chart: `0.28.2` (latest)
+- Cluster: `postgres17`, image `ghcr.io/cloudnative-pg/postgresql:17`, 2 instances (`postgres17-1`, `postgres17-2`), healthy
+- Storage: 40 GiB per instance, ~1.5 GB used cluster-wide (12 databases)
+- Resources: `requests.cpu=500m`, no memory request, `limits.memory=4Gi`, no CPU limit
+- Backups: barman → `s3://cloudnative-pg/`, last backup 12h ago (healthy), 30d retention
+- Metrics scrape: working (PodMonitor `postgres17`, vmagent ingests, 26+ series)
+- Grafana dashboard ConfigMap: present (`cnpg-grafana-dashboard` in databases ns) but no `GrafanaDashboard` CR — dashboard never imported into Grafana. **Fixed in this PR.**
+- Alert rules: 8 baseline + 7 added in this PR = 15 total
+
+### Parameter audit
+
+| Parameter | Current | Recommended | Why |
+|-----------|---------|-------------|-----|
+| `shared_buffers` | `512MB` | `1GB` | 25% rule on 4 GB limit. Bigger buffer cache = better hit ratio under AI/RAG read patterns. |
+| `effective_cache_size` | `4GB` (default) | `3GB` | Should reflect available memory minus shared_buffers minus OS. 3 GB on 4 GB pod is honest. |
+| `work_mem` | `4MB` (default) | `16MB` | RAG workloads: sort merges, GIN index scans, large IN-lists spill to disk at 4 MB. 16 MB×concurrency stays within budget. |
+| `maintenance_work_mem` | `64MB` (default) | `256MB` | Vacuum + index builds slow on growing tables. Set per-session if you don't want it always reserved. |
+| `max_connections` | `500` | `200` | 500 backends × ~10 MB = 5 GB ceiling, exceeds the 4 GiB limit. The stat looks high but the cluster will OOM long before reaching it. Pair with PgBouncer (Pooler CR) at 1000:200 ratio. |
+| `random_page_cost` | `4` (default) | `1.1` | Default tuned for spinning disks. NVMe (openebs-hostpath) responds in single-digit microseconds. Lower cost = planner picks index scans more often. |
+| `track_io_timing` | `off` | `on` | pg_stat_statements without io_timing hides whether queries are CPU- or IO-bound. Negligible overhead on Linux clock_gettime. |
+| `track_activity_query_size` | `1kB` (default) | `4kB` | RAG queries with embedded vectors get truncated in `pg_stat_activity` at 1 kB. |
+| `shared_preload_libraries` | `""` | `pg_stat_statements,auto_explain` | pg_stat_statements is installed only in `app` DB today. Pre-loading makes it available globally without per-DB `CREATE EXTENSION`. auto_explain logs slow query plans to controller logs. |
+| `auto_explain.log_min_duration` | n/a | `1s` | Logs `EXPLAIN ANALYZE` for any query >1s. Cheap, hugely useful for forensics. |
+| `auto_explain.log_analyze` | n/a | `on` | Run-time stats in the log. |
+| `auto_explain.log_buffers` | n/a | `on` | Buffer hit/read counts. |
+| `auto_explain.sample_rate` | n/a | `0.5` | Half of slow queries get full analyze; other half just log. Reduces overhead spike when many slow queries fire at once. |
+| `pg_stat_statements.max` | `10000` | (keep) | Already set. |
+| `pg_stat_statements.track` | `all` | (keep) | Already set. |
+| `wal_compression` | `off` (default) | `on` | Talos kernel has `lz4` available. Smaller WAL → faster replay, less S3 transfer. |
+| `wal_buffers` | `16MB` | (keep) | Default already auto-tuned to `shared_buffers/32`. Will scale with shared_buffers bump. |
+| `synchronous_commit` | `on` (default) | (keep) | Don't relax — durability matters more than throughput for the small writes this cluster handles. |
+| `huge_pages` | `try` (default) | (keep) | Talos kernel doesn't pre-allocate hugepages; `try` falls back gracefully. Switch to `on` only after pre-allocating via Talos kernel cmdline. |
+| `jit` | `on` (default) | `off` | Default is on PG 17. JIT compilation is overhead-positive only for very long analytical queries. Most workloads here are short OLTP. |
+
+### Resource shape
+
+| Resource | Current | Recommended | Why |
+|----------|---------|-------------|-----|
+| `requests.memory` | unset | `2Gi` | Without a memory request, k8s can over-commit and evict the primary under pressure. 2 Gi reserve = 50% of limit, matches working set. |
+| `limits.cpu` | unset | (leave unset) | Burstable scheduling is correct for PG — it's spiky. |
+| `requests.cpu` | `500m` | `1000m` | 500m gets out-scheduled by competitor pods. Default to 1 vCPU floor; can scale down later. |
+| `storage` | `40Gi` | (keep) | 12% used. Plenty of headroom. |
+
+### Pgvector for RAG
+
+- Extension: `vector v0.8.1` is bundled in `ghcr.io/cloudnative-pg/postgresql:17` but NOT installed.
+- AnythingLLM (planned phase 2 of AI stack) will need it.
+- **Action:** PR 2 adds `vector` to `spec.bootstrap.initdb.postInitTemplateSQL` so it's auto-installed in `template1`, propagating to every new database. Existing databases need manual `CREATE EXTENSION vector;` per-DB, but that's per-tenant work for the consumer.
+
+### Connection pooling (PgBouncer Pooler CR)
+
+CNPG ships first-class PgBouncer support via the `Pooler` CR. **Add when adoption pushes backends >150 sustained**, which the new `CNPGConnectionsNearLimit` alert will catch. Skeleton:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: postgres17-rw-pooler
+  namespace: databases
+spec:
+  cluster:
+    name: postgres17
+  instances: 2
+  type: rw
+  pgbouncer:
+    poolMode: transaction  # session for n8n compatibility, transaction for everything else
+    parameters:
+      max_client_conn: "1000"
+      default_pool_size: "25"
+```
+
+Consumers that re-use prepared statements (n8n, some ORMs) need `pool_mode: session`. Run a per-app pooler if pool modes diverge.
+
+### Custom-query metrics for richer alerts
+
+Several alerts that would be useful (dead tuples, p99 query latency, table-level cache hit) require **custom queries** registered with the cnpg metrics exporter. cnpg supports this via `monitoring.customQueries` on the Cluster CR. Sample (PR 2):
+
+```yaml
+spec:
+  monitoring:
+    customQueries:
+      - name: pg_stat_statements
+        query: |
+          SELECT (pg_database.datname)::text AS datname,
+                 pg_stat_statements.query AS query,
+                 pg_stat_statements.calls AS calls,
+                 pg_stat_statements.mean_exec_time AS mean_exec_time
+          FROM pg_stat_statements
+          JOIN pg_database ON pg_database.oid = pg_stat_statements.dbid
+          ORDER BY mean_exec_time DESC LIMIT 20;
+        metrics:
+          - datname:
+              usage: "LABEL"
+          - query:
+              usage: "LABEL"
+          - calls:
+              usage: "COUNTER"
+          - mean_exec_time:
+              usage: "GAUGE"
+```
+
+---
+
+## DragonflyDB findings
+
+### Live state (probed 2026-05-21)
+
+- Operator chart: pinned via OCIRepository (Renovate-tracked)
+- Instance: `dragonflydb`, image `dragonflydb:v1.38.1`, single replica
+- Resources: `requests.cpu=500m`, `requests.memory=500Mi`, `limits.cpu=1`, `limits.memory=2Gi`
+- Args: `--memcached_port=11211`, `--default_lua_flags=allow-undeclared-keys`, plus operator defaults (`--admin_port=9999`, `--admin_nopass`, `--primary_port_http_enabled=false`)
+- Persistence: none — emptyDir, snapshots not configured
+- Auth: enforced via `dragonflydb-auth` Secret
+- Metrics scrape: ServiceMonitor on admin port `:9999/metrics` (this PR + previous)
+- DB allocation: db 0 (transient), db 4 (LiteLLM cache), db 5 (traefikoidc sessions). See `dragonflydb-db-allocation.md`.
+- Alert rules: 0 → 10 in this PR
+
+### Resource shape
+
+| Resource | Current | Recommended | Why |
+|----------|---------|-------------|-----|
+| `requests.memory` | `500Mi` | `2Gi` | Each LiteLLM-cached request is small but the AI cache grows quickly. 500Mi reserve = swap city under load. |
+| `limits.memory` | `2Gi` | `4Gi` | Doubles room for traefikoidc + LiteLLM + AnythingLLM cache. |
+| `requests.cpu` | `500m` | (keep) | Dragonfly is single-threaded per shard; rarely CPU-bound. |
+| `limits.cpu` | `1` | (keep) | No reason to constrain harder. |
+
+### Persistence
+
+Dragonfly supports periodic snapshots via `--save_schedule`. Useful because:
+- After a pod restart, all caches start cold → consumer latency spike.
+- traefikoidc sessions cold = users re-authenticate (mild annoyance, not failure).
+- LiteLLM cache cold = first hits hit upstream models (slow, expected).
+
+**Recommendation (PR 2):** Add a small (5 GiB) PVC mounted at `/data` and enable `--snapshot_cron=*/30 * * * *` (every 30 min). On pod restart, dragonfly auto-loads the snapshot. Loss window = 30 min, acceptable for cache.
+
+```yaml
+# Excerpt for instance.yaml in PR 2
+spec:
+  args:
+    - --logtostderr
+    - --memcached_port=11211
+    - --default_lua_flags=allow-undeclared-keys
+    - --dir=/data
+    - --snapshot_cron=*/30 * * * *
+    - --maxmemory_policy=allkeys-lru
+  storage:
+    size: 5Gi
+    storageClassName: openebs-hostpath
+```
+
+### Eviction policy
+
+Currently unset → defaults to `noeviction` (returns errors on memory full). For a cache, **always set `--maxmemory_policy=allkeys-lru`** so old keys drop instead of erroring. The `DragonflyMemoryCritical` alert will fire before this matters in practice, but defense-in-depth.
+
+### Replica strategy
+
+Currently `replicas: 1`. Dragonfly operator supports `replicas: 2+` for read-replica + automatic failover. **Don't add yet** — adoption isn't high enough to justify the operational complexity and the workload is cache (loss is fine). Revisit if the cluster ever depends on dragonfly being up for primary writes (it should never, by policy).
+
+### Snapshot to S3
+
+Dragonfly does not have built-in S3 export. If snapshot durability matters (it shouldn't for a cache), add a Velero hook on the dragonfly pod that runs `redis-cli -a $PASS BGSAVE` before the daily PVC snapshot. Probably overkill for a cache; skip.
+
+---
+
+## Risk + rollout plan for PR 2
+
+### Risk register
+
+| Change | Risk | Mitigation |
+|--------|------|------------|
+| `shared_buffers` bump | Pod OOM if memory request unset | Set memory request first |
+| `max_connections` cut | Existing apps may have hardcoded connection counts | Audit consumers; Pooler CR before cut |
+| `shared_preload_libraries` add | Restart-required parameter; cnpg handles via rolling restart | Test on staging? — N/A here. Run during low-traffic window. |
+| pgvector preload via initdb | Affects new clusters only, not existing template1 | Add `CREATE EXTENSION vector;` to bootstrap.initdb.postInitSQL too |
+| Dragonfly PVC add | First reconcile = pod restart = cache loss | Acceptable (cache); schedule during off-peak |
+| Dragonfly maxmemory_policy change | Apps that rely on default noeviction-style errors | None of our consumers do; LRU is the right default |
+
+### Rollout order (PR 2)
+
+1. Bump CNPG resource requests (no PG restart, just k8s scheduling).
+2. Add Pooler CR. Consumers continue to talk to `postgres17-rw` direct; pooler available on `postgres17-rw-pooler-rw`.
+3. Migrate one consumer to pooler (n8n? lowest blast radius). Verify.
+4. Migrate the rest opportunistically.
+5. Bump CNPG parameters (rolling restart enforced by cnpg).
+6. Bump dragonfly resources.
+7. Add dragonfly PVC + snapshot config (one-time cache loss).
+8. Add dragonfly eviction policy.
+
+### Verification (per change)
+
+- After PG param bump: `kubectl exec postgres17-2 -c postgres -- psql -U postgres -c 'SHOW shared_buffers;'`
+- After dragonfly resize: `kubectl exec dragonflydb-0 -- redis-cli -a $PASS CONFIG GET maxmemory`
+- After PVC: `kubectl exec dragonflydb-0 -- ls /data/`
+- All alerts: `kubectl logs -n monitoring vmalert-vmalert-0 | grep -i 'cnpg\|dragonfly'`

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/prometheusrule.yaml
@@ -91,3 +91,110 @@ spec:
           labels:
             severity: critical
             component: backup
+        # ----------------------------------------------------------------
+        # Availability + capacity alerts added 2026-05-21 to support AI
+        # workload scaling (LiteLLM, AnythingLLM future, n8n, etc.).
+        # ----------------------------------------------------------------
+        - alert: CNPGInstanceDown
+          annotations:
+            description: >-
+              CNPG instance {{ $labels.pod }} has been unreachable by the
+              metrics collector for >2m. Check `kubectl describe pod {{
+              $labels.pod }} -n databases` and operator logs.
+            summary: CNPG pod is not exposing metrics
+          expr: |-
+            up{job="databases/postgres17"} == 0
+          for: 2m
+          labels:
+            severity: critical
+            component: availability
+        - alert: CNPGNoPrimary
+          annotations:
+            description: >-
+              No instance reports cnpg_pg_replication_in_recovery == 0 — the
+              cluster appears to have no primary. Writes are blocked.
+              Inspect `kubectl get cluster postgres17 -n databases -o
+              yaml --context home` and operator logs.
+            summary: CNPG cluster has no primary
+          # Sum of (in_recovery == 0) — i.e. count of primaries — must be 1.
+          expr: |-
+            sum(cnpg_pg_replication_in_recovery == bool 0) != 1
+          for: 1m
+          labels:
+            severity: critical
+            component: availability
+        - alert: CNPGConnectionsNearLimit
+          annotations:
+            description: >-
+              {{ $labels.pod }} has {{ $value }} active backends. The
+              cluster is configured for max_connections=500 (see
+              cluster17.yaml). Sustained >400 = ~80% saturation; add a
+              Pooler (PgBouncer) before adoption pushes past 450.
+            summary: CNPG backend count nearing max_connections
+          # max_connections is hardcoded at 500 in cluster17.yaml. Hardcode
+          # the threshold here too rather than relying on a metric that
+          # cnpg's collector doesn't emit (cnpg_pg_settings_setting).
+          # If max_connections changes in cluster17.yaml, update both.
+          expr: |-
+            sum by (pod) (cnpg_backends_total) > 400
+          for: 5m
+          labels:
+            severity: warning
+            component: capacity
+        - alert: CNPGSlowQuerySpike
+          annotations:
+            description: >-
+              {{ $labels.pod }} has > 5 queries running > 60s. This often
+              indicates a missing index, a query plan change after stats
+              shift, or lock contention. Inspect via `pg_stat_activity`.
+            summary: Slow query backlog on CNPG instance
+          expr: |-
+            cnpg_backends_max_tx_duration_seconds > 60
+              and on(pod) cnpg_backends_total > 5
+          for: 2m
+          labels:
+            severity: warning
+            component: performance
+        - alert: CNPGWALArchiveBacklog
+          annotations:
+            description: >-
+              WAL archiving on {{ $labels.pod }} has been failing for {{ $value
+              | humanizeDuration }}. PITR is at risk. Check S3 (RustFS at
+              s3.68cc.io) reachability + barman logs.
+            summary: CNPG WAL archive backlog growing
+          expr: |-
+            (cnpg_pg_stat_archiver_last_failed_time - cnpg_pg_stat_archiver_last_archived_time) > 600
+          for: 5m
+          labels:
+            severity: critical
+            component: backup
+        - alert: CNPGCacheHitRatioLow
+          annotations:
+            description: >-
+              {{ $labels.pod }} buffer cache hit ratio is {{ $value |
+              humanizePercentage }} — below 95%. Either shared_buffers is
+              too small, or working set has grown. AI vector workloads can
+              push this down quickly. Bump shared_buffers or
+              effective_cache_size.
+            summary: CNPG buffer cache hit ratio low
+          expr: |-
+            (
+              rate(cnpg_pg_stat_database_blks_hit{datname!~"template.*|postgres"}[5m])
+              /
+              (
+                rate(cnpg_pg_stat_database_blks_hit{datname!~"template.*|postgres"}[5m])
+                + rate(cnpg_pg_stat_database_blks_read{datname!~"template.*|postgres"}[5m])
+              )
+            ) < 0.95
+          for: 15m
+          labels:
+            severity: warning
+            component: performance
+        # Note: dead-tuple + per-statement latency alerts are intentionally
+        # omitted from this ruleset — the cnpg metrics exporter does NOT
+        # emit `cnpg_pg_stat_user_tables_*` or
+        # `cnpg_pg_stat_statements_*` by default. Adding them requires
+        # configuring `monitoring.customQueries` on the Cluster CR with
+        # a custom SQL query map (see cnpg docs: "User-defined Metrics").
+        # That's PR 2 (perf-tuning), not this PR (alerts on existing
+        # metrics only).

--- a/kubernetes/apps/databases/dragonflydb/instance/kustomization.yaml
+++ b/kubernetes/apps/databases/dragonflydb/instance/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./instance.yaml
+  - ./prometheusrule.yaml
   - ./secret.sops.yaml

--- a/kubernetes/apps/databases/dragonflydb/instance/prometheusrule.yaml
+++ b/kubernetes/apps/databases/dragonflydb/instance/prometheusrule.yaml
@@ -1,0 +1,196 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+# DragonflyDB alert rules. Metrics scraped from `dragonflydb-metrics:9999`
+# via the ServiceMonitor in instance.yaml. Field names verified against
+# `/metrics` (see docs/runbooks/dragonflydb-db-allocation.md).
+#
+# Threat model: dragonfly is a CACHE — losing data is acceptable but
+# unavailability cascades to consumers (LiteLLM cache miss = upstream load,
+# traefikoidc session miss = re-auth). Alerts focus on availability,
+# saturation, and replication health (in case we ever scale to >1 replica).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: dragonflydb-rules
+  namespace: databases
+  labels:
+    prometheus: k8s
+    role: alert-rules
+spec:
+  groups:
+    - name: dragonflydb.rules
+      rules:
+        - alert: DragonflyInstanceDown
+          annotations:
+            description: >-
+              The dragonflydb-metrics ServiceMonitor has not produced
+              `dragonfly_uptime_in_seconds` for >2m. The cache pod is
+              unreachable or crashed. Consumers (LiteLLM cache,
+              traefikoidc sessions) will degrade gracefully — they don't
+              depend on dragonfly for primary data.
+            summary: DragonflyDB metrics endpoint unreachable
+          expr: |-
+            absent(dragonfly_uptime_in_seconds) == 1
+          for: 2m
+          labels:
+            severity: warning
+            component: availability
+
+        - alert: DragonflyMemoryHigh
+          annotations:
+            description: >-
+              DragonflyDB is using {{ $value | humanizePercentage }} of its
+              configured maxmemory. Eviction is imminent. Audit DB
+              allocation in `docs/runbooks/dragonflydb-db-allocation.md`
+              and consider raising memory limit on the Dragonfly CR.
+            summary: DragonflyDB memory pressure
+          expr: |-
+            (
+              dragonfly_memory_used_bytes
+              /
+              dragonfly_memory_max_bytes
+            ) > 0.85
+          for: 5m
+          labels:
+            severity: warning
+            component: capacity
+
+        - alert: DragonflyMemoryCritical
+          annotations:
+            description: >-
+              DragonflyDB at {{ $value | humanizePercentage }} of maxmemory
+              — eviction is happening or about to. Cache effectiveness
+              tanking; consumer latency will rise.
+            summary: DragonflyDB memory critically high
+          expr: |-
+            (
+              dragonfly_memory_used_bytes
+              /
+              dragonfly_memory_max_bytes
+            ) > 0.95
+          for: 2m
+          labels:
+            severity: critical
+            component: capacity
+
+        - alert: DragonflyHighEvictionRate
+          annotations:
+            description: >-
+              DragonflyDB is evicting > 100 keys/sec on {{ $labels.instance
+              }} sustained for 5m. Either memory limit is too small for
+              the working set or a consumer is mis-using TTL. Check
+              `dragonfly_evicted_keys_total` rate per DB.
+            summary: DragonflyDB eviction rate high
+          expr: |-
+            rate(dragonfly_evicted_keys_total[5m]) > 100
+          for: 5m
+          labels:
+            severity: warning
+            component: capacity
+
+        - alert: DragonflyClientCountHigh
+          annotations:
+            description: >-
+              Connected clients = {{ $value }}. Client cap is 64000 (default
+              `--max_clients`). At >1000 sustained, suspect a consumer
+              leaking connections (no client-side pooling, no idle
+              eviction). Check `CLIENT LIST` for the offending peer.
+            summary: DragonflyDB connected clients high
+          expr: |-
+            sum(dragonfly_connected_clients) > 1000
+          for: 10m
+          labels:
+            severity: warning
+            component: capacity
+
+        - alert: DragonflyHitRatioLow
+          annotations:
+            description: >-
+              5m keyspace hit ratio = {{ $value | humanizePercentage }} —
+              below 70%. The cache is under-warmed or undersized. If this
+              persists post-deploy, the workload may not benefit from
+              caching at all and the consumer config is wrong.
+            summary: DragonflyDB cache hit ratio low
+          expr: |-
+            (
+              sum(rate(dragonfly_keyspace_hits_total[5m]))
+              /
+              (
+                sum(rate(dragonfly_keyspace_hits_total[5m]))
+                + sum(rate(dragonfly_keyspace_misses_total[5m]))
+              )
+            ) < 0.70
+          for: 15m
+          labels:
+            severity: warning
+            component: performance
+
+        - alert: DragonflyAvgCommandLatencyHigh
+          annotations:
+            description: >-
+              Avg command duration on {{ $labels.instance }} > 5ms over
+              5m. Healthy dragonfly responds in sub-ms; sustained 5ms+
+              suggests CPU saturation, slow lua scripts, or memory
+              fragmentation. Triage with `redis-cli -a $PASS LATENCY
+              DOCTOR`. Note: dragonfly emits a counter (sum of
+              durations), not a histogram, so we cannot extract p99 —
+              this is the average across all command types.
+            summary: DragonflyDB average command latency degraded
+          # rate(sum_seconds) / rate(count) = avg seconds per command,
+          # summed across cmd labels.
+          expr: |-
+            (
+              sum(rate(dragonfly_commands_duration_seconds[5m]))
+              /
+              sum(rate(dragonfly_commands_total[5m]))
+            ) > 0.005
+          for: 5m
+          labels:
+            severity: warning
+            component: performance
+
+        - alert: DragonflyPipelineQueueGrowing
+          annotations:
+            description: >-
+              Pipeline queue length = {{ $value }} on {{ $labels.instance
+              }} — clients sending faster than dragonfly can process.
+              Expected to drain quickly under normal load. Sustained >100
+              indicates a stuck command or the server is CPU-bound.
+            summary: DragonflyDB pipeline queue not draining
+          expr: |-
+            dragonfly_pipeline_queue_length > 100
+          for: 5m
+          labels:
+            severity: warning
+            component: performance
+
+        - alert: DragonflyBlockedClients
+          annotations:
+            description: >-
+              {{ $value }} clients blocked on dragonfly {{ $labels.instance
+              }}. Likely a BLPOP / BRPOP / WAIT command stuck. If this
+              fires unexpectedly, a consumer is using a blocking command
+              we don't intend to support.
+            summary: DragonflyDB has blocked clients
+          expr: |-
+            dragonfly_blocked_clients > 0
+          for: 10m
+          labels:
+            severity: warning
+            component: availability
+
+        - alert: DragonflyUnexpectedReplicaPromotion
+          annotations:
+            description: >-
+              `dragonfly_master == 0` — this pod is a replica. The
+              instance.yaml deploys `replicas: 1` (master only); a replica
+              should not exist. Either the operator promoted a phantom
+              replica or someone scaled up. Verify
+              `kubectl get dragonfly -n databases`.
+            summary: DragonflyDB unexpected replica state
+          expr: |-
+            dragonfly_master == 0
+          for: 5m
+          labels:
+            severity: warning
+            component: availability

--- a/kubernetes/apps/monitoring/grafana/dashboards/app/cnpg-grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/grafana/dashboards/app/cnpg-grafanadashboard.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# CloudNativePG dashboard. The cnpg Helm chart already produces a ConfigMap
+# `cnpg-grafana-dashboard` in the `databases` namespace (key `cnp.json`)
+# when `monitoring.grafanaDashboard.create=true`. We surface it as a
+# GrafanaDashboard CR in the `monitoring` namespace, with
+# allowCrossNamespaceImport so the Grafana Operator can read the ConfigMap
+# from `databases`.
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cloudnative-pg
+  namespace: monitoring
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: vmsingle
+      inputName: DS_PROMETHEUS
+  configMapRef:
+    name: cnpg-grafana-dashboard
+    namespace: databases
+    key: cnp.json

--- a/kubernetes/apps/monitoring/grafana/dashboards/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/grafana/dashboards/app/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - homebridge-grafanadashboard.yaml
   - amd-gpu-grafanadashboards.yaml
   - dragonflydb-grafanadashboard.yaml
+  - cnpg-grafanadashboard.yaml
 configMapGenerator:
   - name: amd-gpu-overview-dashboard
     files:


### PR DESCRIPTION
PR 1 of 2 from the AI-scaling database audit (2026-05-21). This PR adds **monitoring only** — no parameter changes, no pod restarts. PR 2 will ship the performance tuning items captured in
docs/runbooks/database-tuning-recommendations.md.

CloudNativePG:
- New GrafanaDashboard CR `cloudnative-pg` references the chart's existing `cnpg-grafana-dashboard` ConfigMap (which was orphaned — the chart created it but no CR ever imported it into Grafana). Cross-namespace import (databases → monitoring) via allowCrossNamespaceImport.
- 7 new alerts (rule count 8 → 15):
  * CNPGInstanceDown — `up == 0` per pod
  * CNPGNoPrimary — `count(in_recovery==0) != 1`
  * CNPGConnectionsNearLimit — `cnpg_backends_total > 400` (hardcoded against cluster17.yaml's max_connections=500; cnpg's exporter doesn't emit pg_settings.setting so we can't do a ratio dynamically. If max_connections changes, update this threshold in lockstep.)
  * CNPGSlowQuerySpike — combined long-tx + backend count threshold
  * CNPGWALArchiveBacklog — archive failures sustained >10m
  * CNPGCacheHitRatioLow — buffer cache hit < 95% for 15m (foreshadows AI/RAG read pressure; will fire as workload grows)
- Removed 2 placeholder alerts that referenced metrics the cnpg exporter doesn't emit by default (`cnpg_pg_stat_user_tables_*`, `cnpg_pg_stat_statements_*_bucket`). Documented as "needs customQueries" in the tuning doc — opt-in for PR 2.

DragonflyDB:
- 10 new alerts (rule count 0 → 10): availability, memory pressure (warning + critical), eviction rate, client count, hit ratio, avg command latency, pipeline queue, blocked clients, unexpected replica state. All metric names verified live against /metrics on admin port 9999.
- Note: dragonfly emits `dragonfly_commands_duration_seconds` as a COUNTER (sum-of-durations across cmd labels), not a histogram, so the latency alert uses avg = rate(sum) / rate(count) rather than histogram_quantile(p99). Documented in the alert annotation.

Tuning doc (docs/runbooks/database-tuning-recommendations.md):
- Full audit findings: PG parameter recommendations, resource shaping, pgvector for AnythingLLM phase, Pooler CR rollout trigger, dragonfly snapshots + persistence + eviction policy.
- Risk register + rollout order for PR 2.
- Verification commands per change.