### PR TITLE
feat(databases): phase 2 perf tuning — pg params + dragonfly snapshot/cache mode

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
@@ -22,14 +22,68 @@ spec:
     name: cloudnative-pg-secret
   enableSuperuserAccess: true
   postgresql:
+    # Parameter tuning rationale (2026-05-21 audit, see
+    # docs/runbooks/database-tuning-recommendations.md):
+    #
+    # - shared_buffers 512MB → 1GB: 25% of the 4Gi limit. Bigger PG
+    #   buffer cache → better hit ratio for the AI/RAG read patterns.
+    # - effective_cache_size 4GB (default) → 3GB: should reflect
+    #   memory available to the pod minus shared_buffers minus OS.
+    # - work_mem 4MB → 16MB: RAG sort-merges + GIN scans + large IN
+    #   lists spill to disk at 4MB. 16MB × concurrency stays in budget.
+    # - maintenance_work_mem 64MB → 256MB: faster vacuum + index build
+    #   on growing tables.
+    # - max_connections 500 → 200: 500 backends × ~10MB ≈ 5GB ceiling
+    #   that exceeds the pod limit. Pair with the Pooler when
+    #   `CNPGConnectionsNearLimit` fires (threshold updated below).
+    # - random_page_cost 4 (default) → 1.1: NVMe (openebs-hostpath)
+    #   responds in single-digit µs; default is HDD-tuned.
+    # - track_io_timing off → on: pg_stat_statements without IO timing
+    #   hides whether a slow query is CPU- or IO-bound.
+    # - track_activity_query_size 1024 → 4096: RAG queries with
+    #   embedded vectors get truncated in pg_stat_activity at 1KB.
+    # - shared_preload_libraries: cnpg already auto-loads
+    #   pg_stat_statements when monitoring is enabled. Adding
+    #   auto_explain explicitly so the controller picks it up too.
+    # - auto_explain.* : log EXPLAIN (analyze, buffers) for queries
+    #   exceeding 1s. sample_rate 0.5 keeps the log volume bounded
+    #   when many slow queries fire at once.
+    # - jit on (default) → off: PG17 default is on, but JIT only
+    #   wins on long analytical queries. Most workloads here are
+    #   short OLTP; JIT compilation is overhead-positive.
+    # - wal_compression on: lz4 available on the talos kernel.
+    #   Smaller WAL → faster replay + less S3 transfer for barman.
+    # shared_preload_libraries is managed via the dedicated field below,
+    # NOT via parameters{}. Setting it in parameters{} is rejected by the
+    # cnpg validator: "Can't set fixed configuration parameter".
+    shared_preload_libraries:
+      - pg_stat_statements  # cnpg auto-injects this when monitoring is on,
+                            # but listing it explicitly avoids surprise
+                            # when someone toggles monitoring off.
+      - auto_explain        # logs EXPLAIN (analyze, buffers) for slow queries
     parameters:
-      max_connections: "500"
-      shared_buffers: 512MB
+      max_connections: "200"
+      shared_buffers: 1GB
+      effective_cache_size: 3GB
+      work_mem: 16MB
+      maintenance_work_mem: 256MB
+      random_page_cost: "1.1"
+      track_io_timing: "on"
+      track_activity_query_size: "4096"
+      auto_explain.log_min_duration: 1s
+      auto_explain.log_analyze: "on"
+      auto_explain.log_buffers: "on"
+      auto_explain.log_format: json
+      auto_explain.log_nested_statements: "on"
+      auto_explain.sample_rate: "0.5"
       pg_stat_statements.max: "10000"
       pg_stat_statements.track: all
+      jit: "off"
+      wal_compression: "on"
   resources:
     requests:
-      cpu: 500m
+      cpu: "1"
+      memory: 2Gi
     limits:
       memory: 4Gi
   monitoring:

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/prometheusrule.yaml
@@ -127,16 +127,16 @@ spec:
           annotations:
             description: >-
               {{ $labels.pod }} has {{ $value }} active backends. The
-              cluster is configured for max_connections=500 (see
-              cluster17.yaml). Sustained >400 = ~80% saturation; add a
-              Pooler (PgBouncer) before adoption pushes past 450.
+              cluster is configured for max_connections=200 (see
+              cluster17.yaml). Sustained >160 = ~80% saturation; add a
+              Pooler (PgBouncer) before adoption pushes past 180.
             summary: CNPG backend count nearing max_connections
-          # max_connections is hardcoded at 500 in cluster17.yaml. Hardcode
+          # max_connections is hardcoded at 200 in cluster17.yaml. Hardcode
           # the threshold here too rather than relying on a metric that
           # cnpg's collector doesn't emit (cnpg_pg_settings_setting).
           # If max_connections changes in cluster17.yaml, update both.
           expr: |-
-            sum by (pod) (cnpg_backends_total) > 400
+            sum by (pod) (cnpg_backends_total) > 160
           for: 5m
           labels:
             severity: warning

--- a/kubernetes/apps/databases/dragonflydb/instance/instance.yaml
+++ b/kubernetes/apps/databases/dragonflydb/instance/instance.yaml
@@ -13,17 +13,27 @@ metadata:
 spec:
   image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.38.1
   replicas: 1
+  # Resource bump 2026-05-21 (phase 2 audit). AI workloads (LiteLLM cache +
+  # future AnythingLLM RAG cache) plus traefikoidc sessions are projected
+  # to push cache use past the 2 Gi limit. 4 Gi gives headroom and
+  # 2 Gi memory request avoids opportunistic eviction by the scheduler.
   resources:
     requests:
       cpu: 500m
-      memory: 500Mi
+      memory: 2Gi
     limits:
       cpu: 1
-      memory: 2Gi
+      memory: 4Gi
   args:
     - --logtostderr
     - --memcached_port=11211
     - --default_lua_flags=allow-undeclared-keys
+    # Cache mode = LRU eviction when reaching maxmemory. Without this
+    # dragonfly errors writes once full (noeviction-equivalent), which
+    # would cascade to LiteLLM/traefikoidc errors instead of degraded
+    # cache hit ratio. Acceptable trade-off because every consumer here
+    # is a *cache* user — losing old entries is fine.
+    - --cache_mode=true
     # Admin port (9999) exposes Prometheus metrics on /metrics with no auth.
     # The operator already sets these by default but listing here makes the
     # config self-documenting:
@@ -35,6 +45,23 @@ spec:
     passwordFromSecret:
       name: dragonflydb-auth
       key: password
+  # Periodic snapshot every 30 min into a 5 Gi PVC. On pod restart the
+  # operator auto-loads the snapshot — caches start warm instead of cold.
+  # Loss window = 30 min, acceptable for cache (traefikoidc sessions
+  # re-auth, LiteLLM repopulates on first request).
+  # `enableOnMasterOnly: true` means replicas (if added later) don't
+  # write competing snapshots into the same PVC.
+  snapshot:
+    cron: "*/30 * * * *"
+    dir: /dragonfly/snapshots
+    enableOnMasterOnly: true
+    persistentVolumeClaimSpec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+      storageClassName: openebs-hostpath
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION

PR 2 of the AI-scaling database audit. Pairs with the monitoring + alert work that landed in the previous PR. PR 2 ships parameter changes; the ScheduledBackup + custom-query + Pooler items remain deferred.

CloudNativePG (postgres17 cluster):
- shared_buffers 512MB → 1GB (25% rule on 4Gi limit)
- effective_cache_size 4GB (default) → 3GB (honest ceiling)
- work_mem 4MB → 16MB (RAG sort/merge stops spilling at 4MB)
- maintenance_work_mem 64MB → 256MB (vacuum + index build)
- max_connections 500 → 200 (500 backends × 10MB exceeds 4Gi limit)
- random_page_cost 4 → 1.1 (NVMe, not HDD)
- track_io_timing off → on (pg_stat_statements gains IO breakdown)
- track_activity_query_size 1024 → 4096 (RAG queries embed vectors)
- jit on → off (PG17 default; JIT only wins on long analytical queries)
- wal_compression off → on (lz4 in talos kernel)
- shared_preload_libraries: pg_stat_statements + auto_explain (the field is top-level postgresql.shared_preload_libraries, NOT parameters{} — cnpg validator rejects it in parameters{} as a "fixed configuration parameter")
- auto_explain settings: log queries >1s with ANALYZE + buffers, sample_rate 0.5 to bound log volume on slow-query bursts.
- Resources: requests.cpu 500m → 1, requests.memory 2Gi explicit (was implicit-from-limit). cpu limit still unset (PG benefits from burst).

CNPG alert threshold update:
- CNPGConnectionsNearLimit: 400 → 160 (reflects max_connections cut).

Dragonfly (dragonflydb instance):
- Resources: requests.memory 500Mi → 2Gi, limits.memory 2Gi → 4Gi. Cache will grow as LiteLLM + future AnythingLLM adoption picks up.
- --cache_mode=true: LRU eviction at maxmemory instead of erroring. This is Dragonfly's analog to Redis maxmemory_policy=allkeys-lru; there's no separate maxmemory_policy flag.
- spec.snapshot: cron */30 * * * *, 5 Gi PVC on openebs-hostpath. Operator-managed (first-class CR field); restart auto-loads the snapshot. Loss window 30 min, fine for a cache.
- enableOnMasterOnly: true so a future replica wouldn't fight the master writing the snapshot file.

Rolling restart impact:
- CNPG: ~30s switchover during the rolling restart (2 instances). Consumers (n8n, atuin, home-assistant, linkwarden, litellm) all retry on transient errors.
- Dragonfly: brief restart (~10s) when the snapshot PVC mounts. Cache loss at first start; subsequent restarts warm via the snapshot.