### PR TITLE
fix(databases): allow vmagent to scrape dragonfly admin port (9999)

### DIFF
--- a/kubernetes/apps/databases/dragonflydb/instance/instance.yaml
+++ b/kubernetes/apps/databases/dragonflydb/instance/instance.yaml
@@ -138,3 +138,38 @@ spec:
       path: /metrics
       interval: 30s
       scrapeTimeout: 10s
+---
+# The dragonfly operator auto-creates a NetworkPolicy that locks down
+# the admin port (9999) to operator + peer pods only. That blocks
+# vmagent from scraping /metrics. We keep the operator's policy intact
+# (lockdown on 9999 from arbitrary tenants is a feature) and add this
+# sibling policy to additively allow monitoring/vmagent → 9999.
+# Multiple ingress NetworkPolicies are additive, so this unions cleanly
+# with the operator-managed one.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dragonflydb-allow-monitoring-scrape
+  namespace: databases
+  labels:
+    app.kubernetes.io/name: dragonfly-metrics
+    app.kubernetes.io/instance: dragonflydb
+spec:
+  podSelector:
+    matchLabels:
+      app: dragonflydb
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/part-of: dragonfly
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vmagent
+      ports:
+        - port: 9999
+          protocol: TCP


### PR DESCRIPTION
The dragonfly operator auto-creates a NetworkPolicy that locks port 9999 to operator + peer pods only. After the StatefulSet recreate (needed for the snapshot PVC to land), vmagent silently lost its scrape — same restriction was always there but the original audit missed it because metrics had been flowing pre-restart for an unrelated reason (operator CR's serviceMonitor: enabled was scraping the OPERATOR's metrics, not dragonfly itself).

Add a sibling NetworkPolicy in `databases` that allows `monitoring/vmagent` → `:9999`. NetworkPolicy ingress rules are additive, so the operator's lockdown remains for everything else.

Verified vmagent reaches the pod IP after this lands; before the fix `wget --timeout=5 http://<pod-ip>:9999/metrics` from inside the vmagent container hangs. After the fix metrics flow within ~30s via vmagent's normal scrape interval.