### PR TITLE
fix(databases): use home-ops/role label for dragonfly metrics svc/SM …

### DIFF
--- a/kubernetes/apps/databases/dragonflydb/instance/instance.yaml
+++ b/kubernetes/apps/databases/dragonflydb/instance/instance.yaml
@@ -95,13 +95,18 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  # Flux's parent Kustomization (kubernetes/apps/databases/dragonflydb/ks.yaml)
+  # injects `commonMetadata.labels.app.kubernetes.io/name: dragonflydb-instance`,
+  # which overwrites any `app.kubernetes.io/name` we set on this Service.
+  # We use a distinct label `home-ops/role: dragonfly-metrics` for the
+  # ServiceMonitor selector so it can't be clobbered by Flux's labelling.
   labels:
     app: dragonflydb
     app.kubernetes.io/component: Dragonfly
     app.kubernetes.io/instance: dragonflydb
     app.kubernetes.io/part-of: dragonfly-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: dragonfly-metrics
+    home-ops/role: dragonfly-metrics
   name: dragonflydb-metrics
   namespace: databases
 spec:
@@ -127,12 +132,12 @@ metadata:
   name: dragonflydb
   namespace: databases
   labels:
-    app.kubernetes.io/name: dragonfly-metrics
+    home-ops/role: dragonfly-metrics
     app.kubernetes.io/instance: dragonflydb
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: dragonfly-metrics
+      home-ops/role: dragonfly-metrics
   endpoints:
     - port: metrics
       path: /metrics


### PR DESCRIPTION
…selector

Flux's parent Kustomization at kubernetes/apps/databases/dragonflydb/ks.yaml injects `commonMetadata.labels` cluster-wide, including `app.kubernetes.io/name: dragonflydb-instance`. That OVERWRITES the `app.kubernetes.io/name: dragonfly-metrics` we set on the metrics Service, so the ServiceMonitor's `selector.matchLabels` finds zero Services. Symptom: vmagent target reports `(0/0 up)` despite Service + EndpointSlice being healthy.

Switch to a distinct `home-ops/role: dragonfly-metrics` label that Flux won't clobber. Both the Service and ServiceMonitor use it.

Verified live: pre-fix `kubectl get svc -l app.kubernetes.io/name=dragonfly-metrics` returned 0 Services. Post-fix the SM selector matches via the unique label.