### PR TITLE
feat(databases): cnpg ClusterImageCatalog + version-stable Service aliases

### DIFF
--- a/docs/runbooks/cnpg-major-upgrade.md
+++ b/docs/runbooks/cnpg-major-upgrade.md
@@ -13,48 +13,70 @@ These should already exist in the repo (delivered by phase 1 of the upgrade plan
 - `kubernetes/apps/databases/cloudnative-pg/cluster/service-aliases.yaml` — version-stable `postgres-{rw,r,ro}` ExternalName Services aliasing the cnpg-managed `postgres17-{rw,r,ro}`.
 - (Phase 2) Cluster CR uses `imageCatalogRef` instead of `imageName`.
 
-## Upgrade plan: 4 PRs
+## Upgrade plan: 3 PRs
 
-### PR 1 — Image catalog + service aliases (no downtime)
+### PR 1 — Image catalog + service aliases + bullseye→bookworm distro hop (one rolling restart)
 
 **Branch:** `feat/cnpg-imagecatalog-svc-alias`
 
-Adds the `ClusterImageCatalog` and ExternalName Service aliases. Cluster CR continues to use `imageName: …:17` so nothing changes at the operator level. Pure additive.
+Single PR delivers:
+- `ClusterImageCatalog/postgresql` with bookworm digests for major 17 + 18
+- ExternalName Service aliases `postgres-{rw,r,ro}` → cnpg-managed `postgres17-*`
+- Cluster CR switches from `imageName: …:17` (moving tag, bullseye) to `imageCatalogRef` at major 17 (digest-pinned, **bookworm**)
 
-After merge: `kubectl get clusterimagecatalog postgresql -o yaml` shows the catalog. `nslookup postgres-rw.databases.svc.cluster.local` from any pod resolves to the cnpg-managed Service.
+This effects a same-major distro hop (PG17 bullseye → PG17 bookworm) in a single rolling restart. The distro hop is required by cnpg before any major-version upgrade — operator rejects bullseye→bookworm and PG17→PG18 simultaneously per the OS-compatibility constraint.
 
-### PR 2 — Switch Cluster CR to imageCatalogRef (one rolling restart)
+**Manual pre-merge step (defensive, recommended):**
 
-**Manual pre-merge step (REQUIRED):**
+CNPG validation rejects a Cluster CR that has BOTH `imageName` and `imageCatalogRef`. Flux uses server-side apply with its own field manager (`kustomize-controller`), which DOES drop `imageName` correctly when our manifest doesn't include it — verified via dry-run with `--field-manager=kustomize-controller`. Bare `kubectl apply` (different default manager) shows the failure; Flux is fine.
 
-CNPG validation rejects a Cluster CR that has BOTH `imageName` and `imageCatalogRef`. Server-side apply unions fields — Flux's apply will fail with:
-
-```
-The Cluster "postgres17" is invalid: spec: Invalid value: imageName and imageCatalogRef are mutually exclusive
-```
-
-Pre-clear the field on the live object **immediately before** merging the PR:
+Despite Flux being able to handle it, the safer move is to clear `imageName` manually before the merge so the operator's first reconcile sees ONLY `imageCatalogRef` and there's zero ambiguity:
 
 ```bash
 rtk kubectl patch cluster postgres17 -n databases --context home \
   --type=json -p='[{"op":"remove","path":"/spec/imageName"}]'
 ```
 
-The cluster keeps running on the same image (cnpg caches the resolved digest). Then merge the PR. Flux applies `imageCatalogRef`, operator reconciles, sees the catalog points at the same major (17) → resolves to the pinned digest → MAY trigger one rolling restart if the digest differs from what's running on the moving `:17` tag.
+The cluster keeps running on the same image (cnpg caches the resolved digest). Then merge the PR. Flux applies `imageCatalogRef`, operator reconciles, sees the catalog's bookworm digest for major 17 differs from the bullseye digest currently running → triggers a rolling restart that lands on bookworm.
 
-**Expected impact:** ~30s switchover during the rolling restart. Consumers retry.
+If you skip the manual patch and Flux SSA still works as expected, no harm done. If something gets confused mid-reconcile, run the patch and force a reconcile:
+
+```bash
+rtk kubectl patch cluster postgres17 -n databases --context home \
+  --type=json -p='[{"op":"remove","path":"/spec/imageName"}]'
+rtk flux reconcile ks cloudnative-pg-cluster -n flux-system --context home
+```
+
+**Expected impact:** ~30s write-unavailable during primary switchover. Consumers retry. Replicas re-provision their PVCs at the new image.
 
 **Verification post-merge:**
 
 ```bash
-rtk kubectl get cluster postgres17 -n databases --context home -o jsonpath='{.spec.imageCatalogRef}'
+# Confirm bookworm
+rtk kubectl exec -n databases postgres17-2 -c postgres --context home -- \
+  bash -c 'cat /etc/os-release | grep VERSION_CODENAME'
+# VERSION_CODENAME=bookworm
+
+# Confirm catalog ref
+rtk kubectl get cluster postgres17 -n databases --context home \
+  -o jsonpath='{.spec.imageCatalogRef}'
 # {"apiGroup":"postgresql.cnpg.io","kind":"ClusterImageCatalog","name":"postgresql","major":17}
 
-rtk kubectl get pods -n databases -l cnpg.io/cluster=postgres17 --context home
-# 2/2 Running
+# Confirm health
+rtk kubectl get cluster postgres17 -n databases --context home
+# 2/2 Ready, primary set, healthy
+
+# Spot-check consumer connectivity
+for app in litellm n8n authentik home-assistant; do
+  echo "=== $app ==="
+  rtk kubectl logs -n <ns> -l app.kubernetes.io/name=$app --tail=10 --context home | \
+    grep -iE 'error|connection|failed' | head -3 || echo "  ok"
+done
 ```
 
-### PR 3 — Take fresh backup + bump major to 18 (downtime expected)
+**Verification window:** soak the bookworm cluster for at least 24h before proceeding to PR 2. Watch for autovacuum behavior changes, glibc-driven collation surprises (PG17 retains the same default ICU collation across distros, but spot-check `\dC` output if you have queries that depend on collation order), and any consumer warnings.
+
+### PR 2 — Take fresh backup + bump major to 18 (downtime expected)
 
 **Manual pre-merge step (REQUIRED):**
 
@@ -103,7 +125,7 @@ in `kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml`.
 | Linkwarden | UI 5xx; resumes |
 | Memos / Paperless | Disabled, irrelevant |
 
-### PR 4 — Post-upgrade verification (no downtime)
+### PR 3 — Post-upgrade verification (no downtime)
 
 **Manual post-merge steps:**
 

--- a/docs/runbooks/cnpg-major-upgrade.md
+++ b/docs/runbooks/cnpg-major-upgrade.md
@@ -1,0 +1,206 @@
+# CNPG Major-Version PostgreSQL Upgrade Runbook
+
+**Status:** procedure documented; PG17 → PG18 upgrade pending.
+**Last reviewed:** 2026-05-25 (cnpg operator 1.29.1, cluster on PG 17.6 bullseye).
+
+Reference: https://cloudnative-pg.io/docs/1.29/postgres_upgrades/
+
+## Prerequisites
+
+These should already exist in the repo (delivered by phase 1 of the upgrade plan, branch `feat/cnpg-imagecatalog-svc-alias`):
+
+- `kubernetes/apps/databases/cloudnative-pg/cluster/imagecatalog.yaml` — `ClusterImageCatalog/postgresql` with pinned digests for major 17 and 18 from the bullseye line.
+- `kubernetes/apps/databases/cloudnative-pg/cluster/service-aliases.yaml` — version-stable `postgres-{rw,r,ro}` ExternalName Services aliasing the cnpg-managed `postgres17-{rw,r,ro}`.
+- (Phase 2) Cluster CR uses `imageCatalogRef` instead of `imageName`.
+
+## Upgrade plan: 4 PRs
+
+### PR 1 — Image catalog + service aliases (no downtime)
+
+**Branch:** `feat/cnpg-imagecatalog-svc-alias`
+
+Adds the `ClusterImageCatalog` and ExternalName Service aliases. Cluster CR continues to use `imageName: …:17` so nothing changes at the operator level. Pure additive.
+
+After merge: `kubectl get clusterimagecatalog postgresql -o yaml` shows the catalog. `nslookup postgres-rw.databases.svc.cluster.local` from any pod resolves to the cnpg-managed Service.
+
+### PR 2 — Switch Cluster CR to imageCatalogRef (one rolling restart)
+
+**Manual pre-merge step (REQUIRED):**
+
+CNPG validation rejects a Cluster CR that has BOTH `imageName` and `imageCatalogRef`. Server-side apply unions fields — Flux's apply will fail with:
+
+```
+The Cluster "postgres17" is invalid: spec: Invalid value: imageName and imageCatalogRef are mutually exclusive
+```
+
+Pre-clear the field on the live object **immediately before** merging the PR:
+
+```bash
+rtk kubectl patch cluster postgres17 -n databases --context home \
+  --type=json -p='[{"op":"remove","path":"/spec/imageName"}]'
+```
+
+The cluster keeps running on the same image (cnpg caches the resolved digest). Then merge the PR. Flux applies `imageCatalogRef`, operator reconciles, sees the catalog points at the same major (17) → resolves to the pinned digest → MAY trigger one rolling restart if the digest differs from what's running on the moving `:17` tag.
+
+**Expected impact:** ~30s switchover during the rolling restart. Consumers retry.
+
+**Verification post-merge:**
+
+```bash
+rtk kubectl get cluster postgres17 -n databases --context home -o jsonpath='{.spec.imageCatalogRef}'
+# {"apiGroup":"postgresql.cnpg.io","kind":"ClusterImageCatalog","name":"postgresql","major":17}
+
+rtk kubectl get pods -n databases -l cnpg.io/cluster=postgres17 --context home
+# 2/2 Running
+```
+
+### PR 3 — Take fresh backup + bump major to 18 (downtime expected)
+
+**Manual pre-merge step (REQUIRED):**
+
+```bash
+# Trigger on-demand backup
+rtk kubectl cnpg backup postgres17 -n databases --context home
+
+# Wait + verify
+rtk kubectl get backup -n databases --context home
+# Status should be "completed" before proceeding
+
+# Sanity: object exists in S3
+aws --endpoint-url https://s3.68cc.io s3 ls s3://cloudnative-pg/postgres17-v4/base/ --recursive | tail -3
+```
+
+**PR content:**
+
+```diff
+- major: 17
++ major: 18
+```
+
+in `kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml`.
+
+**What happens after merge:**
+
+1. Operator detects `major:` change.
+2. Stops all cluster pods (writes blocked from this point).
+3. Validates new image, prepares a fresh PGDATA directory.
+4. Runs `pg_upgrade --link` (sub-second per database; hardlinks, doesn't copy).
+5. Replaces directories.
+6. Destroys replica PVCs and re-provisions them at the new version.
+7. Cluster comes back up on PG18.
+
+**Expected window:** 5–15 min for ~1.5 GB across 12 databases on openebs-hostpath.
+
+**Consumer impact during downtime:**
+
+| Consumer | Behavior |
+|----------|----------|
+| LiteLLM | Gateway stays up; cache-served requests succeed; uncached → upstream fallback if cloud keys configured, else 503 |
+| n8n | Workflow runs queue; UI shows DB-down; jobs resume after primary returns |
+| Atuin | Sync errors logged; client retries on next sync |
+| Home Assistant | Recorder integration logs errors; HA itself stays running |
+| Authentik | Auth flows fail mid-flow; new flows wait |
+| Linkwarden | UI 5xx; resumes |
+| Memos / Paperless | Disabled, irrelevant |
+
+### PR 4 — Post-upgrade verification (no downtime)
+
+**Manual post-merge steps:**
+
+```bash
+# 1. Version check
+rtk kubectl cnpg psql postgres17 -n databases --context home -- -tAc 'SELECT version();'
+# Expected: PostgreSQL 18.4 (Debian ...) on x86_64...
+
+# 2. Cluster healthy
+rtk kubectl get cluster postgres17 -n databases --context home
+# 2/2 Ready, primary set
+
+# 3. ANALYZE every non-template DB (pg_upgrade doesn't transfer optimizer stats)
+for DB in $(rtk kubectl cnpg psql postgres17 -n databases --context home -- -tAc \
+  "SELECT datname FROM pg_database WHERE datistemplate=false AND datname<>'postgres';"); do
+  echo "=== ANALYZE $DB ==="
+  rtk kubectl cnpg psql postgres17 -n databases --context home -- -d "$DB" -c "ANALYZE VERBOSE;"
+done
+
+# 4. Reset pg_stat_statements (counters meaningless across version boundary)
+rtk kubectl cnpg psql postgres17 -n databases --context home -- -c "SELECT pg_stat_statements_reset();"
+
+# 5. Spot-check consumer connectivity
+for ns_app in ai/litellm ai/n8n services/home-assistant security/authentik; do
+  ns="${ns_app%/*}"; app="${ns_app#*/}"
+  echo "=== $ns/$app ==="
+  rtk kubectl logs -n "$ns" -l app.kubernetes.io/name="$app" --tail=10 --context home | grep -iE 'error|connection|failed' | head -5 || echo "  ok"
+done
+
+# 6. Take fresh post-upgrade backup
+rtk kubectl cnpg backup postgres17 -n databases --context home
+```
+
+## Rollback paths
+
+| Stage | Recovery |
+|-------|----------|
+| Before PR 3 merge | Just don't merge. Catalog + aliases are inert. |
+| PR 3 merged but pg_upgrade hasn't completed | Revert the `major: 18 → 17` PR. Operator resumes the old version on the original PGDATA (cnpg's `--link` mode preserves it). |
+| pg_upgrade completed but consumers broken | Revert `major: 18 → 17`. Operator restores from the pre-upgrade backup taken in PR 3 prereq via `bootstrap.recovery`. **Bump `serverName` to `postgres17-v5`** in cluster17.yaml's `spec.backup.barmanObjectStore` so WAL archives don't collide with the old timeline. |
+| Disaster (data loss) | `bootstrap.recovery.source` from `postgres17-v4` (last pre-upgrade serverName) into a fresh cluster. ~1 GB recovery is fast. |
+
+## Consumer migration to `postgres-rw` alias (opportunistic)
+
+The new ExternalName Services let consumers reference the database without the version in the hostname:
+
+| Old | New |
+|-----|-----|
+| `postgres17-rw.databases.svc.cluster.local` | `postgres-rw.databases.svc.cluster.local` |
+| `postgres17-r.databases.svc.cluster.local` | `postgres-r.databases.svc.cluster.local` |
+| `postgres17-ro.databases.svc.cluster.local` | `postgres-ro.databases.svc.cluster.local` |
+
+**Don't bulk-migrate.** Each consumer's secret is SOPS-encrypted; touching them all at once is high-risk. Instead, migrate when a consumer's secret is next being edited for any reason (rotated password, new field, etc.).
+
+**Inventory of consumers as of 2026-05-25** (from `git grep postgres17`):
+
+- `kubernetes/apps/security/authentik/app/{helmrelease.yaml,secret.sops.yaml}`
+- `kubernetes/apps/security/crowdsec/app/helmrelease.yaml`
+- `kubernetes/apps/ai/litellm/app/{helmrelease.yaml,secret.sops.yaml}`
+- `kubernetes/apps/ai/n8n/app/secret.sops.yaml`
+- `kubernetes/apps/services/home-assistant/app/{helmrelease.yaml,secret.sops.yaml}`
+- `kubernetes/apps/services/atuin/app/secret.sops.yaml`
+- `kubernetes/apps/services/linkwarden/app/secret.sops.yaml`
+- `kubernetes/apps/services/memos/app/secret.sops.yaml` (disabled)
+- `kubernetes/apps/services/paperless/app/secret.sops.yaml` (disabled)
+- `kubernetes/apps/services/metamcp/app/{helmrelease.yaml,secret.sops.yaml}`
+- `kubernetes/apps/velero/exclusions/app/pvc-exclusions.yaml`
+- `kubernetes/apps/databases/cloudnative-pg/cluster/{tlsroute.yaml,prometheusrule.yaml,scheduledbackup.yaml}` (operator references; leave as-is)
+
+Direct references to internal cnpg objects (`tlsroute.yaml`, `prometheusrule.yaml`, `scheduledbackup.yaml`) MUST keep using `postgres17-*` because they reference the cnpg-managed Cluster and Services BY NAME. These are not consumer connection strings.
+
+**Procedure to migrate one consumer:**
+
+```bash
+# 1. Decrypt
+task sops:decrypt-file file=kubernetes/apps/<ns>/<app>/secret.sops.yaml
+
+# 2. Edit: replace `postgres17-rw` → `postgres-rw` (and -r/-ro variants)
+
+# 3. Re-encrypt
+task sops:encrypt-file file=kubernetes/apps/<ns>/<app>/secret.sops.yaml
+
+# 4. Verify
+task sops:verify
+
+# 5. Same migration in helmrelease.yaml if env values reference postgres17 directly
+
+# 6. Commit + push, single-app PR
+```
+
+## Future major bumps (PG18 → PG19 etc.)
+
+Once on imageCatalogRef, the procedure shrinks to:
+
+1. Add the new major to `imagecatalog.yaml`.
+2. Take backup.
+3. Bump `major:` on the Cluster CR.
+4. Run ANALYZE.
+
+The OS-distro constraint still applies — verify the catalog has a bullseye image for the target major. If upstream drops bullseye, the upgrade becomes blue/green via dump/restore (different runbook; not yet authored).

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
@@ -6,7 +6,23 @@ metadata:
   name: postgres17
 spec:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:17
+  # Image is pinned via the ClusterImageCatalog `postgresql` (sibling
+  # imagecatalog.yaml, bookworm digests). To bump the major version,
+  # change `major:` to a value present in that catalog. Patch versions
+  # roll forward when the catalog itself is bumped (separate PR).
+  # Procedure: docs/runbooks/cnpg-major-upgrade.md.
+  #
+  # NOTE: imageName + imageCatalogRef are mutually exclusive at the
+  # cnpg webhook layer. If the live Cluster object still has imageName
+  # set (legacy state pre-this-PR), Flux's apply will fail validation.
+  # Pre-merge step (one-time, documented in runbook):
+  #   kubectl patch cluster postgres17 -n databases --context home \
+  #     --type=json -p='[{"op":"remove","path":"/spec/imageName"}]'
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    name: postgresql
+    major: 17
   description: "Shared PG17 Cluster"
   primaryUpdateStrategy: unsupervised
   # Exclude CNPG PVCs from Velero fs-backup — data is already shipped to

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/imagecatalog.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/imagecatalog.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/clusterimagecatalog_v1.json
+# Cluster-scoped catalog of pinned PG images. Cluster CRs reference this
+# via `spec.imageCatalogRef` + `major: <N>` instead of hardcoding
+# `imageName`. Major upgrades become a one-line `major: 17` → `major: 18`
+# change on the Cluster CR.
+#
+# Images pinned to specific digests (NOT moving tags) so a Renovate-driven
+# tag bump can't silently roll the running cluster — operator only
+# reconciles when this catalog changes. Update procedure: bump tag/digest
+# below in a dedicated PR; Renovate is configured against the upstream
+# `cloudnative-pg/postgresql` Docker tag (see customManagers).
+#
+# Source of truth for image digests:
+#   https://github.com/cloudnative-pg/postgres-containers/blob/main/Debian/ClusterImageCatalog-bullseye.yaml
+#
+# We use the bullseye line (NOT bookworm) because the existing cluster's
+# pgdata is bullseye-built. cnpg requires same-OS for in-place upgrades
+# per https://cloudnative-pg.io/docs/1.29/postgres_upgrades/
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql
+spec:
+  images:
+    # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql versioning=loose
+    - major: 17
+      image: ghcr.io/cloudnative-pg/postgresql:17.10-202605180839-system-bullseye@sha256:5656486b022a9c0850f399dfdad37183667c53595d466c232f1d9b58500d958f
+    # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql versioning=loose
+    - major: 18
+      image: ghcr.io/cloudnative-pg/postgresql:18.4-202605180839-system-bullseye@sha256:70516d5620512874419f653939ea6c672a354172a10ffc6c90c073334b1423ec

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/imagecatalog.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/imagecatalog.yaml
@@ -12,11 +12,18 @@
 # `cloudnative-pg/postgresql` Docker tag (see customManagers).
 #
 # Source of truth for image digests:
-#   https://github.com/cloudnative-pg/postgres-containers/blob/main/Debian/ClusterImageCatalog-bullseye.yaml
+#   https://github.com/cloudnative-pg/postgres-containers/blob/main/Debian/ClusterImageCatalog-bookworm.yaml
 #
-# We use the bullseye line (NOT bookworm) because the existing cluster's
-# pgdata is bullseye-built. cnpg requires same-OS for in-place upgrades
-# per https://cloudnative-pg.io/docs/1.29/postgres_upgrades/
+# OS distro: bookworm (Debian 12). The existing cluster started on
+# bullseye; PR 2 of the upgrade plan does a same-major bullseye->bookworm
+# distro hop (PG17 bullseye -> PG17 bookworm), then PR 3 does the
+# PG17->PG18 bump on bookworm. cnpg requires same-OS for the major-
+# version step (https://cloudnative-pg.io/docs/1.29/postgres_upgrades/),
+# so the distro hop has to land first.
+#
+# Trixie is NOT yet shipped by cnpg-postgres-containers as of 2026-05-25.
+# When that lands upstream, this catalog can be updated to trixie tags
+# in a future PR. Bookworm is supported by upstream Debian through 2028.
 apiVersion: postgresql.cnpg.io/v1
 kind: ClusterImageCatalog
 metadata:
@@ -25,7 +32,7 @@ spec:
   images:
     # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql versioning=loose
     - major: 17
-      image: ghcr.io/cloudnative-pg/postgresql:17.10-202605180839-system-bullseye@sha256:5656486b022a9c0850f399dfdad37183667c53595d466c232f1d9b58500d958f
+      image: ghcr.io/cloudnative-pg/postgresql:17.10-202605180839-system-bookworm@sha256:a95ccc35635f55aecaed2687f4a8f7af684f8ad4ba48bae8a61119fbd9714083
     # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql versioning=loose
     - major: 18
-      image: ghcr.io/cloudnative-pg/postgresql:18.4-202605180839-system-bullseye@sha256:70516d5620512874419f653939ea6c672a354172a10ffc6c90c073334b1423ec
+      image: ghcr.io/cloudnative-pg/postgresql:18.4-202605180839-system-bookworm@sha256:cd34e2e24b2009d1dd1ef1ecfd392c9634e0bd483958fa46ce4d6839cfb1d49f

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
@@ -3,7 +3,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./imagecatalog.yaml
   - ./cluster17.yaml
+  - ./service-aliases.yaml
   - ./scheduledbackup.yaml
   - ./prometheusrule.yaml
   - ./grafanadashboard.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/service-aliases.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/service-aliases.yaml
@@ -1,0 +1,73 @@
+---
+# Version-stable Service aliases for the cnpg-managed cluster.
+#
+# CNPG creates Service names from the Cluster CR's `metadata.name`:
+#   <cluster-name>-rw  (writable, primary only)
+#   <cluster-name>-r   (read-only, all instances)
+#   <cluster-name>-ro  (read-only, replicas only)
+#
+# Our Cluster is named `postgres17`, so consumers historically reference
+# `postgres17-rw.databases.svc.cluster.local`. Renaming a cnpg Cluster
+# CR is destructive — operator deletes/recreates the StatefulSet — so
+# we keep the underlying name and add ExternalName aliases that don't
+# carry a version. New apps should reference these aliases. Existing
+# apps migrate opportunistically when their secrets are next touched.
+#
+# Aliases:
+#   postgres-rw → postgres17-rw  (write traffic; primary only)
+#   postgres-r  → postgres17-r   (read traffic; all instances incl. primary)
+#   postgres-ro → postgres17-ro  (read traffic; replicas only)
+#
+# When PG18 lands and operator-managed services rename to postgres18-*,
+# we update the externalName here in one place. Consumers' connection
+# strings stay stable.
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-rw
+  namespace: databases
+  labels:
+    app.kubernetes.io/component: cnpg-alias
+    app.kubernetes.io/instance: postgres17
+spec:
+  type: ExternalName
+  externalName: postgres17-rw.databases.svc.cluster.local
+  ports:
+    - name: postgres
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-r
+  namespace: databases
+  labels:
+    app.kubernetes.io/component: cnpg-alias
+    app.kubernetes.io/instance: postgres17
+spec:
+  type: ExternalName
+  externalName: postgres17-r.databases.svc.cluster.local
+  ports:
+    - name: postgres
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-ro
+  namespace: databases
+  labels:
+    app.kubernetes.io/component: cnpg-alias
+    app.kubernetes.io/instance: postgres17
+spec:
+  type: ExternalName
+  externalName: postgres17-ro.databases.svc.cluster.local
+  ports:
+    - name: postgres
+      port: 5432
+      protocol: TCP
+      targetPort: 5432

--- a/kubernetes/apps/security/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/security/authentik/app/helmrelease.yaml
@@ -28,18 +28,7 @@ spec:
             name: authentik-secrets
 
     authentik:
-      secret_key: "${AUTHENTIK_SECRET_KEY}"
       log_level: info
-      postgresql:
-        host: postgres17-rw.databases.svc.cluster.local
-        name: authentik
-        user: authentik
-        password: "${AUTHENTIK_POSTGRES_PASSWORD}"
-      redis:
-        host: dragonflydb.databases.svc.cluster.local
-        port: 6379
-        password: "${DRAGONFLYDB_PASSWORD}"
-        db: 6
 
     server:
       resources:

--- a/kubernetes/apps/security/authentik/app/secret.sops.yaml
+++ b/kubernetes/apps/security/authentik/app/secret.sops.yaml
@@ -3,30 +3,39 @@ kind: Secret
 metadata:
   name: authentik-secrets
 stringData:
-  AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:5fzBAhJI5tvW4vjpQH69WGuRG1jvJ9uXweLrovec0CMxOEvSxYSAMdNECCrsP5lldyvCxmQnv19FOqZxzWUz5ZuYExM=,iv:2nXdU/52If5Ez7zyTFXFtoExhWdkM/9CNyCbIj7eUCA=,tag:+vxTcTi5iq2wtasa+5d13Q==,type:str]
-  AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:Nds19wOEgOXJN5pcl88xLVCugj61xpBMJOWaykquyvM=,iv:OBRh+61+kYHojc+8nvNcRxx72Z7yCVMM+6a/CFsEnGI=,tag:g+XCI1EAwBAT75g97dlJyw==,type:str]
-  AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:/1Sx2kffYbfMbA/Lq677cBmNb7Gvcj+0CRN9vQzIZgaOTmgk+Nl4AUhv5dU1kgQGjM9e2d3QHprIeGc/IsWdyw==,iv:PhEUyJKfUgSF2on5ewyBkP/40iVPL+6eFHafkTkv2bE=,tag:fg8KO+It+YZuIUstOYgwow==,type:str]
-  AUTHENTIK_POSTGRES_PASSWORD: ENC[AES256_GCM,data:cGvrXpgA3gPkEQd3irqYCuDpYR+Q5JaqgHBGcnyFx+qVqrDJZ0XKzWcJsVo=,iv:JKj8N4g6mIPSn/8rb7p1m7KXHZE9W173bYpXdC+hUMw=,tag:0f3UP8DYvdS4pCLK5huMmA==,type:str]
-  INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:i461Ai0rTuwZ,iv:SXolHNMs4oh64WOyWkexljbrInCDgEfnoq6lr+vycRE=,tag:Y9wRMmMF/7xvg78sAtM50Q==,type:str]
-  INIT_POSTGRES_HOST: ENC[AES256_GCM,data:a8NWrKDHnlhahp55OY8GTqnr6IDIrnuriIOHRCQydN+nKMNr+oP+PIA=,iv:Fx7n1trGOw1Ui7VXgF+10iyuT/hXcBd1GHcF5VqgvXo=,tag:hsTFBfSBnLqrQTuU2nNRGg==,type:str]
-  INIT_POSTGRES_USER: ENC[AES256_GCM,data:E3AR5i2mLtIj,iv:5N6qxKmo+D7lTS0Nd6K73oUta5qmS9ENY+4lahGI94c=,tag:jNOQ9Kc2UziAptROui6/tw==,type:str]
-  INIT_POSTGRES_PASS: ENC[AES256_GCM,data:A5pgm9pmuiiDzwboNNdbjuOVvXIC80bn+dcpVYIXoYVTdW6ILrVHttZkHt8=,iv:sYDRn/Ph8rIqe33n2LNvHQhZM/hL7/Z8f/qa6f9spDg=,tag:v+F7cXiuLIfaD/14Kbshvw==,type:str]
-  INIT_POSTGRES_SUPER_USER: ENC[AES256_GCM,data:lO7i9MNq0Vc=,iv:ttpa9poaIi8O22fPbMDWMuZ+lhuLkLe99mRcNFA/LqA=,tag:VPYOUWZwQhN3cpA6AGcGgQ==,type:str]
-  INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:KVLgJelo6jEJCOZp6m4=,iv:HjsuhpCh7iCADiD6Chvlrfc3LCkWQXJjuM1GXV1Oy60=,tag:o+xstyXIrsYv3sWvW2SPPw==,type:str]
-  DRAGONFLYDB_PASSWORD: ENC[AES256_GCM,data:X/yl1ZBKROcv/USZgtTVuQ5MUwHNZHKeUBn5da2+/Zw=,iv:LqUYlXTUjBJjcQFAn/Ruuf7gDI8ZyE30ML9ALMpjvFQ=,tag:+tSVpz9tvxG7GUFHIJs02Q==,type:str]
+  AUTHENTIK_SECRET_KEY: ENC[AES256_GCM,data:G9LIAedfqeNaNVfgRon986G1/kPPCycvTnjZf8GTSQak8z1n6jeLdaSDtfO8163s5MZKcgS0K5eisS6VI0ruADPwhzw=,iv:6LySuPF0+mM3Le0vCPIMRzAmqKX4HsFhlCAd0xpf9U8=,tag:Ng3z/psDFuQFStgJM/JCxg==,type:str]
+  AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:SjdhFf7kIQLFjVhn7LEI/zvxZ+wsvWb/xNjAN0m1KzE=,iv:Yy4bZ5Em5HHVpkNBZF0U8zbDWSGWO1N2LzhdokwzVo8=,tag:n1T/rnhtaH9wj4OdQ49dEg==,type:str]
+  AUTHENTIK_BOOTSTRAP_TOKEN: ENC[AES256_GCM,data:a3yo7CWr1dDOP0PSLTcs2+u7Op8q317DOFo5xRbau6JlpgCOcjZvc6RSW1GCSEvu4AJ4TdqYWisvs1cQKg9Ogw==,iv:69IFvytkpA4BonbKmhzvHPh6oCeDmTOAlgcIKWQuXY0=,tag:Cev+4cV9cjw217T8j6bmGg==,type:str]
+  AUTHENTIK_POSTGRES_PASSWORD: ENC[AES256_GCM,data:UrXE5ciOXLDkBiHk+pPOzVC4zMvbcZ6cqHMTx2l+MLsw0ESFyz2tWGsj6WI=,iv:cAKK8Z2mr+MBXYvN3n1qFpRpU/iQZ09EktAm8jmwmRI=,tag:AMA5aNVMb4Ujs9ZSn6ee9A==,type:str]
+  #ENC[AES256_GCM,data:SLSydgjEteshkFWCzS/slJRAchyupdPRqcQtVh8ZojUoL+pT4w1LBoN4hYUypNTLTjADSXdkknGuHCX+c3c6SXRvLGNAylO2qw==,iv:cU/JA0oQbX5PW1P6A2jGnfo3JsprI7z1la6LOTiE8iI=,tag:0cmhID5AwZGFZlOTGNhWug==,type:comment]
+  AUTHENTIK_POSTGRESQL__HOST: ENC[AES256_GCM,data:yivV93TiEwRtVsD/Wn38pytTFga2YjuqpF4xmpHoYLjRIlWPyVLdM6g=,iv:IS1tq+MUdLXh4PMBoIb/P4hws5l8LhiQihLo0Oc5Syg=,tag:NGzDeqxX3E9q81z5C/Udyg==,type:str]
+  AUTHENTIK_POSTGRESQL__NAME: ENC[AES256_GCM,data:WG3LxP6B5NKL,iv:LbYBMtIWqTki5kQHJkeZzFyVi2PTpp7Qaw2LaK06wbk=,tag:Wx2FDTBAVH5PO0zON875TA==,type:str]
+  AUTHENTIK_POSTGRESQL__USER: ENC[AES256_GCM,data:AXM6uHK7vJzF,iv:EDW4/PLSpS3kkewpOi5rhsnVqp9kRo+NzPkcNkCj7jc=,tag:VC/tqAclIp69HMdCbN/Ysg==,type:str]
+  AUTHENTIK_POSTGRESQL__PASSWORD: ENC[AES256_GCM,data:F8ENgjV+wdyTqT7gWhvUz8YHvHooK8n6cxdC2AcgbbEVT1EKN1QNuAQxDiI=,iv:Ttmt9pITagebugM1ZsqllH1ahmG9c07ZCEAFmRtlRYY=,tag:/I9Sx+iIGLVFAaykvpSF6A==,type:str]
+  AUTHENTIK_REDIS__HOST: ENC[AES256_GCM,data:D4yjQF2owmvXWLJF62s+L4FkWNNdGDM2RpileobVVxnr3RqK++8t,iv:WH6bauaDccKmYUe6N4A5bTiH7SzBv6wdXjiXuZ+9L4U=,tag:s3B6MIZXradsqVVcIhcSTQ==,type:str]
+  AUTHENTIK_REDIS__PORT: ENC[AES256_GCM,data:zmecWw==,iv:fqcb8B/qO8KDcJhR3BCM2rEMiUFWAQ3RORb4SktU6jA=,tag:sVR+vnY2gQIvkj90QDyTJQ==,type:str]
+  AUTHENTIK_REDIS__PASSWORD: ENC[AES256_GCM,data:GOriupU46d8lLHN4+puA3VSTqbol4waPZhfag/Ajy8g=,iv:2ZdwLKSDk7DjwENJquV4NTFwE+GlYA4lbwGRc5mWGc4=,tag:yyp6hZlx6yOU0HGPk0Et4g==,type:str]
+  AUTHENTIK_REDIS__DB: ENC[AES256_GCM,data:zA==,iv:EWy2xOJxltzHG6HRv8KIKm/7YCBIOMLkbxfh6Cmar+U=,tag:t95dTFykFrBZa5cCA85peQ==,type:str]
+  INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:NZLG8tRKCfXZ,iv:njewzjKyjgaPQCFFY9XbUkRSM+cjxXzGM/UwqLT3UOs=,tag:z812WphTGZheqYP7ZNuVpQ==,type:str]
+  INIT_POSTGRES_HOST: ENC[AES256_GCM,data:qHJ82GftdnaZZ3kfLCorgUK2r9e43fA3b6M51HJNdN5JKljgnjmlY+c=,iv:icGU+j3RklVC6FqI/MCcaPVKNhyL8NzVXzJ92+F3aD8=,tag:+b1Zw/LGnyyln20JYgLgxg==,type:str]
+  INIT_POSTGRES_USER: ENC[AES256_GCM,data:jXPGPfPU7Zcm,iv:s0xKfx5hh4tfYb6VeeJaqvpRJ7lXh+e9cawckkCuJGA=,tag:HELHCPC5JMPm1ZosafToeg==,type:str]
+  INIT_POSTGRES_PASS: ENC[AES256_GCM,data:Yz1/dapXdJlA09wcHdR6Id78pjhARPPvSi6C8f0vlK9vmglDmBTesr7dUYI=,iv:BHBu9N8KcUDoCoDRSza7Xecv5yJ/8qeB7QkXQm/hiFc=,tag:I5t53aiJNbBCuXwJzsKJxg==,type:str]
+  INIT_POSTGRES_SUPER_USER: ENC[AES256_GCM,data:zDDl8oKwcKw=,iv:8O1GQaQfJl0+X64tv265d9fmTUbLzRHbDx3EInU1tRw=,tag:D9cgMzrWJ1G8XaC6g2eC0Q==,type:str]
+  INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:FXi1CHFMYido+qmtDWM=,iv:lEUvmIL87OqSYa6zr8V38DH3gQxzVMs7+/gadMW/ffM=,tag:mg4Q+rAxHA9nJvBTrf2m0g==,type:str]
+  DRAGONFLYDB_PASSWORD: ENC[AES256_GCM,data:tYMWpfIT0q7ng5pGSQnz762L6iLmh1+OboNqwY8u5ew=,iv:yS2Gw1G9dC/YxJMRJSGhrcLkJAnXGifCgzHCT3dOeuA=,tag:GwiE9zAq3aP01/gDtKj6dg==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLZzJyRTBPVDhnU3U4S1Uy
-        ZjN2a2hRU1c0MmFJMENEOG0waUY0RStWV3dJClBpbnpyZVIyNnVWbS9zcndRKzlr
-        T1BaUE9PRUZscnJLcjdSY2ZwRGF4Qm8KLS0tIGFUV3Z6T0lYZHZvL1FOaUV4aWJh
-        d0IzOWlVbzBYREVsbUJPeVVsaHVmQmcK/YJgE5pSlJz6l2sPRxln1v4rh47FdUHh
-        GVxWpU8LDvKmCKlb/2xzC93bkdOLHV77xK+2DYkH55aum3ahJq8xSg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOOWI5Q3VBeVdDYnN1QjFs
+        cnc4c3BjV3FsV3duVEVzdUkyTm9sSTVmelFFCmdUdEdRc0hvZGVveEVrelNZSi9B
+        dDA1OTRvSlFaOUF0NEkra21MUkhZUUUKLS0tIGpSOER6RTBxMHdTU2M3cmxCdita
+        V3M3bjhETjE1MXRiNmZqNmZPbHpsaGcKPL9aPlXI+lZ6VRxZl7vHSVcfQukvyNNe
+        0KfNbSbzQ9xbLrxulf+uJkf6847s0VGtAMkFyyNtD1E73dtlukNHpw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1qwwzsz6z2mmu6hpmjt2he7nepmnhutmhehvkva7l5zy5xzf08d5s5n4d6n
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-05-21T17:54:09Z"
-  mac: ENC[AES256_GCM,data:w0pNEV86KRXMFx7BY9NK9B1asQoOrcJVunNIuhkOaBVBf41IY3LrxXmEKpIIvyLbS9ISRTvy0auUzKvGeeQjOtZFsis+45afqkhY11g/Zpqd+OsR6NVkmQCHbtafSaRKoZoq9jxcRiy5hrlTh2bFzzTHN6OcxaX69Ic6IId7ras=,iv:mO9ZbAUFXz1mp2tCLc+a4ajISkmggRd21+6JR4fMASU=,tag:WKI9LNxGuh5m115AVRy8iQ==,type:str]
+  lastmodified: "2026-05-25T21:48:14Z"
+  mac: ENC[AES256_GCM,data:UB8gxearIpR3WorjYmk4rI0VwqQL5XXR5Bc/3o0F6wkuHj2ryshf69eOwofuD+flXEReEG611upJbYehBMmH0TabwNQTMpNLnw0lthO22MiW2+sxKNsX27Q+EhzTLDE3JyCmORhkcz5yPqsALbN3cLknrdC8XBMGpBLDhMmELlU=,iv:RHBEJ/W0PLEaRdj0r3bX4u017u/zVqlRpsZ1UmfhyIg=,tag:gSZjvQ3qy91L0jobpmwJRg==,type:str]
   mac_only_encrypted: true
   version: 3.13.1


### PR DESCRIPTION
PR 1 of 4 in the PG17 -> PG18 upgrade plan. Pure additive — no Cluster CR change in this PR, so no operator-driven restart. Cluster keeps running on the existing imageName for now; PR 2 switches to imageCatalogRef after a manual pre-merge step (cnpg validates imageName + imageCatalogRef as mutually exclusive).

Adds:
- imagecatalog.yaml: ClusterImageCatalog/postgresql with pinned digests for major 17 + 18 from the bullseye line. Both pulled from the upstream catalog at cloudnative-pg/postgres-containers@main. Pinning to digests (not :17) means a Renovate-driven retag can't silently roll the running cluster.
- service-aliases.yaml: ExternalName Services postgres-{rw,r,ro} → postgres17-{rw,r,ro}. Lets new consumers reference a hostname that doesn't carry the version, so PG18+ migrations don't require touching every consumer secret. Existing consumers migrate opportunistically via the runbook checklist.
- docs/runbooks/cnpg-major-upgrade.md: 4-PR procedure + manual steps
  + rollback paths + per-consumer migration checklist.

Server-side dry-run verified clean. Cluster CR continues to use the moving :17 tag; that gets cleaned up in PR 2.