### PR TITLE
feat(databases): migrate cnpg backups to barman-cloud plugin

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
@@ -104,34 +104,28 @@ spec:
       memory: 4Gi
   monitoring:
     enablePodMonitor: true
-  backup:
-    retentionPolicy: 30d
-    barmanObjectStore: &barmanObjectStore
-      data:
-        compression: bzip2
-      wal:
-        compression: bzip2
-        maxParallel: 8
-      destinationPath: s3://cloudnative-pg/
-      endpointURL: https://s3.68cc.io
-      # Note: serverName version needs to be incremented
-      # when recovering from an existing cnpg cluster
-      serverName: &currentCluster postgres17-v4
-      s3Credentials:
-        accessKeyId:
-          name: cloudnative-pg-secret
-          key: S3_ACCESS_KEY_ID
-        secretAccessKey:
-          name: cloudnative-pg-secret
-          key: S3_SECRET_ACCESS_KEY
-  # Note: previousCluster needs to be set to the name of the previous
-  # cluster when recovering from an existing cnpg cluster
+  # Backups are managed by the cnpg-barman-cloud plugin. The plugin owns
+  # backup config via an ObjectStore CR (sibling objectstore.yaml). The
+  # in-tree spec.backup.barmanObjectStore block was removed in favour of
+  # spec.plugins[]. Plugin reads/writes the same s3://cloudnative-pg/
+  # path with the same serverName=postgres17-v4 — full backup continuity.
+  #
+  # See docs/runbooks/cnpg-major-upgrade.md PR 3 for the migration plan
+  # and docs/runbooks/cnpg-barman-plugin-migration.md for full reference.
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: postgres17-v4
+  # Recovery source for new instances bootstrapping from S3.
+  # `externalClusters[].plugin` replaces the legacy `barmanObjectStore`
+  # block — points at the postgres17-v3 ObjectStore CR.
   bootstrap:
     recovery:
       source: &previousCluster postgres17-v3
-  # Note: externalClusters is needed when recovering from an existing cnpg cluster
   externalClusters:
     - name: *previousCluster
-      barmanObjectStore:
-        <<: *barmanObjectStore
-        serverName: *previousCluster
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: postgres17-v3

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./imagecatalog.yaml
   - ./cluster17.yaml
   - ./service-aliases.yaml
+  - ./objectstore.yaml
   - ./scheduledbackup.yaml
   - ./prometheusrule.yaml
   - ./grafanadashboard.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/objectstore.yaml
@@ -1,0 +1,59 @@
+---
+# Barman Cloud Plugin ObjectStore CR — replacement for the in-tree
+# spec.backup.barmanObjectStore block on the Cluster CR.
+#
+# The S3 path, retention policy, compression, and credentials all match
+# what was previously inline. `serverName` carries through unchanged so
+# the plugin reads/writes the SAME barman repo at s3://cloudnative-pg/postgres17-v4/.
+# This is critical for backup continuity — same path means PITR archives,
+# previous base backups, and WAL segments remain valid.
+#
+# A second ObjectStore exists for the recovery source (postgres17-v3),
+# referenced by spec.externalClusters in cluster17.yaml.
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: postgres17-v4
+  namespace: databases
+spec:
+  configuration:
+    destinationPath: s3://cloudnative-pg/
+    endpointURL: https://s3.68cc.io
+    serverName: postgres17-v4
+    s3Credentials:
+      accessKeyId:
+        name: cloudnative-pg-secret
+        key: S3_ACCESS_KEY_ID
+      secretAccessKey:
+        name: cloudnative-pg-secret
+        key: S3_SECRET_ACCESS_KEY
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8
+  # Retention policy lives on the ObjectStore (was on Cluster.spec.backup
+  # in the in-tree model).
+  retentionPolicy: 30d
+---
+# Recovery-source ObjectStore. cluster17.yaml's spec.bootstrap.recovery
+# references the original postgres17-v3 cluster (pre-current-incarnation).
+# That historical S3 path needs its own ObjectStore so the plugin can
+# read it. Not used for ongoing backups — pure recovery-time config.
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: postgres17-v3
+  namespace: databases
+spec:
+  configuration:
+    destinationPath: s3://cloudnative-pg/
+    endpointURL: https://s3.68cc.io
+    serverName: postgres17-v3
+    s3Credentials:
+      accessKeyId:
+        name: cloudnative-pg-secret
+        key: S3_ACCESS_KEY_ID
+      secretAccessKey:
+        name: cloudnative-pg-secret
+        key: S3_SECRET_ACCESS_KEY

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -11,3 +11,10 @@ spec:
   cluster:
     name: postgres17
   target: "prefer-standby"
+  # Plugin-managed backups (cnpg 1.30 will remove the in-tree path).
+  # The cluster's spec.plugins[] declares the barman-cloud plugin; this
+  # method directs ScheduledBackup runs through it instead of the
+  # default cnpg-internal barman-cloud-backup invocation.
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/kubernetes/apps/databases/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/ks.yaml
@@ -34,6 +34,11 @@ spec:
   dependsOn:
     - name: cloudnative-pg
       namespace: *namespace
+    # Cluster CR references spec.plugins[barman-cloud.cloudnative-pg.io].
+    # Need the plugin operator running before reconcile, otherwise cnpg
+    # webhook rejects the Cluster as referencing an unknown plugin.
+    - name: cnpg-barman-plugin
+      namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/databases/cloudnative-pg/cluster
   prune: true

--- a/kubernetes/apps/databases/cnpg-barman-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/cnpg-barman-plugin/app/helmrelease.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# CNPG Barman Cloud plugin operator. Replaces the in-tree
+# spec.backup.barmanObjectStore on the Cluster CR (deprecated in
+# cnpg 1.26, removed in 1.30).
+#
+# Architecture:
+# - Operator Deployment runs in `databases` ns alongside the cnpg operator.
+# - It owns the new ObjectStore CRD (barmancloud.cnpg.io/v1).
+# - The cluster's Cluster CR references it via spec.plugins[].
+# - cert-manager-issued cert authenticates the cnpg-i gRPC stream
+#   (operator <-> plugin); chart auto-creates a self-signed Issuer.
+#
+# Deployment order: this HelmRelease lands first, ObjectStore CR + Cluster
+# spec.plugins changes lands second (in `cluster17.yaml`'s next PR or
+# even this same PR — whichever is staged). Until the Cluster references
+# the plugin, the operator sits idle.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cnpg-barman-plugin
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: cnpg-barman-plugin
+  install:
+    remediation:
+      retries: 3
+    crds: CreateReplace
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+    crds: CreateReplace
+  values:
+    # Resource asks bumped from chart defaults (which are unset). Keep
+    # consistent with the cnpg operator's footprint.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+    # Chart 0.6.0 has no built-in monitoring stanza. If we want a
+    # ServiceMonitor for the plugin operator's metrics endpoint, add a
+    # standalone resource (file-level) similar to dragonfly's approach.
+    # Not blocking for the migration; defer to a follow-up.

--- a/kubernetes/apps/databases/cnpg-barman-plugin/app/kustomization.yaml
+++ b/kubernetes/apps/databases/cnpg-barman-plugin/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/databases/cnpg-barman-plugin/app/ocirepository.yaml
+++ b/kubernetes/apps/databases/cnpg-barman-plugin/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cnpg-barman-plugin
+spec:
+  interval: 12h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/charts/plugin-barman-cloud
+    tag: 0.6.0
+  url: oci://ghcr.io/cloudnative-pg/charts/plugin-barman-cloud

--- a/kubernetes/apps/databases/cnpg-barman-plugin/ks.yaml
+++ b/kubernetes/apps/databases/cnpg-barman-plugin/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cnpg-barman-plugin
+  namespace: &namespace databases
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  # The cnpg-i plugin runs as a sidecar against the existing cnpg
+  # operator. Wait for cnpg operator to be installed first.
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/databases/cnpg-barman-plugin/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 10m
+  wait: true

--- a/kubernetes/apps/databases/kustomization.yaml
+++ b/kubernetes/apps/databases/kustomization.yaml
@@ -7,4 +7,5 @@ components:
   - ../../components/repos/app-template
 resources:
   - ./cloudnative-pg/ks.yaml
+  - ./cnpg-barman-plugin/ks.yaml
   - ./dragonflydb/ks.yaml


### PR DESCRIPTION
Replaces in-tree spec.backup.barmanObjectStore on the Cluster CR with the out-of-tree barman-cloud plugin (cnpg-i). The in-tree path is deprecated as of cnpg 1.26 and will be removed in 1.30; the system image flavor we currently use bundles barman binaries but is itself deprecated and will be removed once the plugin is the only path.

Pipeline of changes (split into 3 logical groups):

1. Plugin operator deployment
   - kubernetes/apps/databases/cnpg-barman-plugin/{ks,app/{kustomization, ocirepository,helmrelease}}.yaml
   - OCIRepository points at oci://ghcr.io/cloudnative-pg/charts/plugin-barman-cloud:0.6.0
   - HelmRelease deploys the plugin operator + ObjectStore CRD into the databases ns alongside cnpg
   - dependsOn cloudnative-pg (operator) — plugin sits beside, doesn't replace, the cnpg operator
   - serviceMonitor not yet wired (chart 0.6.0 has no monitoring stanza; follow-up if metrics scrape needed)

2. ObjectStore CRs (cluster/objectstore.yaml)
   - postgres17-v4: current cluster's barman repo. Carries the same destinationPath, endpointURL, retention, compression, credentials, and CRITICALLY the same serverName=postgres17-v4 the in-tree config had. Backup data continuity preserved at s3://cloudnative-pg/postgres17-v4/
   - postgres17-v3: recovery-source ObjectStore for spec.bootstrap.recovery (historical previous-cluster path). Points at the same S3 bucket with serverName=postgres17-v3. Pure read-side config.

3. Cluster CR migration (cluster/cluster17.yaml + scheduledbackup.yaml)
   - Removed: spec.backup{} block (entire barmanObjectStore inline)
   - Removed: spec.externalClusters[].barmanObjectStore inline
   - Added: spec.plugins[] with barman-cloud.cloudnative-pg.io, isWALArchiver=true, parameters.barmanObjectName=postgres17-v4
   - Updated: spec.externalClusters[].plugin replaces the inline barmanObjectStore for the recovery source
   - ScheduledBackup: method=plugin + pluginConfiguration.name= barman-cloud.cloudnative-pg.io. Same daily schedule.

4. Wiring
   - kubernetes/apps/databases/kustomization.yaml: add cnpg-barman-plugin ks.yaml as a sibling to cloudnative-pg
   - cloudnative-pg/ks.yaml: add cnpg-barman-plugin as a dependsOn for the cluster ks (cnpg webhook rejects Cluster CRs that reference unknown plugins; plugin must reconcile first)

Pre-merge: take a fresh in-tree backup via 'kubectl cnpg backup' and verify it lands in S3 BEFORE merging. The in-tree path keeps working on the system image until this PR lands; rollback path is to revert the PR which restores the inline backup config.

Server-side dry-run verified clean for:
- HelmRelease + OCIRepository (plugin operator app)
- Cluster CR (after the plugin) — webhook accepts plugin reference
- ObjectStore CRs error 'no matches for kind' on dry-run because the CRD doesn't exist yet — Flux's dependsOn ordering handles that
- ScheduledBackup with plugin method validates clean

OS image flavor swap (system-trixie -> standard-trixie) deliberately deferred to PR 4. Doing both at once is high-risk because standard images don't ship barman binaries; if the plugin doesn't reconcile correctly, in-tree backup fallback is gone.