### PR TITLE
fix(databases): move serverName off ObjectStore + add kubectl-cnpg

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -31,6 +31,16 @@ BEADS_DOLT_SHARED_SERVER = "1"
 "aqua:cilium/cilium-cli" = "0.19.4"
 "aqua:cli/cli" = "2.92.0"
 "aqua:cloudflare/cloudflared" = "2026.5.1"
+# kubectl-cnpg CLI plugin: invokes via `kubectl cnpg <subcmd>` for
+# on-demand backups, version checks, major-upgrade verification.
+# Version tracks cnpg operator chart in databases/cloudnative-pg/.
+#
+# Renovate caveat: the customManagers regex extracts depName as the
+# 3-segment aqua identifier `cloudnative-pg/cloudnative-pg/kubectl-cnpg`,
+# but GitHub releases live at the 2-segment repo path. Auto-bump will
+# silently no-op for this entry. Bump manually when the cnpg operator
+# HelmRelease (kubernetes/apps/databases/cloudnative-pg/app/) gets bumped.
+"aqua:cloudnative-pg/cloudnative-pg/kubectl-cnpg" = "1.29.1"
 "aqua:cue-lang/cue" = "0.16.1"
 "aqua:FiloSottile/age" = "1.3.1"
 "aqua:fluxcd/flux2" = "2.8.8"

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
@@ -116,10 +116,18 @@ spec:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
+        # `barmanObjectName` references the ObjectStore CR by metadata.name
+        # (sibling objectstore.yaml). The ObjectStore carries S3 location +
+        # credentials + retention. Path-within-bucket is set HERE via
+        # `serverName` — the plugin's webhook rejects serverName on the
+        # ObjectStore itself, so it has to live on the Cluster's plugin
+        # parameters instead. Same ObjectStore CR could serve multiple
+        # clusters with different per-cluster serverNames.
         barmanObjectName: postgres17-v4
+        serverName: postgres17-v4
   # Recovery source for new instances bootstrapping from S3.
   # `externalClusters[].plugin` replaces the legacy `barmanObjectStore`
-  # block — points at the postgres17-v3 ObjectStore CR.
+  # block — points at the postgres17-v3 ObjectStore CR + its own serverName.
   bootstrap:
     recovery:
       source: &previousCluster postgres17-v3
@@ -129,3 +137,4 @@ spec:
         name: barman-cloud.cloudnative-pg.io
         parameters:
           barmanObjectName: postgres17-v3
+          serverName: postgres17-v3

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/objectstore.yaml
@@ -2,14 +2,20 @@
 # Barman Cloud Plugin ObjectStore CR — replacement for the in-tree
 # spec.backup.barmanObjectStore block on the Cluster CR.
 #
-# The S3 path, retention policy, compression, and credentials all match
-# what was previously inline. `serverName` carries through unchanged so
-# the plugin reads/writes the SAME barman repo at s3://cloudnative-pg/postgres17-v4/.
-# This is critical for backup continuity — same path means PITR archives,
-# previous base backups, and WAL segments remain valid.
+# Field-placement note (cnpg-i v0.6.0 webhook):
+#   - The S3 location, credentials, and retention live HERE.
+#   - `serverName` lives on the Cluster's spec.plugins[].parameters,
+#     NOT on ObjectStore.spec.configuration. The webhook explicitly
+#     rejects serverName at the ObjectStore level:
+#       "spec.configuration.serverName: Forbidden: use the 'serverName'
+#        plugin parameter in the Cluster resource"
+#   - `barmanObjectName` (the ObjectStore CR's metadata.name) is referenced
+#     from the Cluster's plugin parameters; the same ObjectStore can serve
+#     multiple clusters by varying serverName per consumer.
 #
-# A second ObjectStore exists for the recovery source (postgres17-v3),
-# referenced by spec.externalClusters in cluster17.yaml.
+# Backup continuity: the cluster references serverName=postgres17-v4 in
+# its plugin parameters, so the plugin reads/writes the SAME S3 path at
+# s3://cloudnative-pg/postgres17-v4/ that the in-tree config used.
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
@@ -19,7 +25,6 @@ spec:
   configuration:
     destinationPath: s3://cloudnative-pg/
     endpointURL: https://s3.68cc.io
-    serverName: postgres17-v4
     s3Credentials:
       accessKeyId:
         name: cloudnative-pg-secret
@@ -40,6 +45,8 @@ spec:
 # references the original postgres17-v3 cluster (pre-current-incarnation).
 # That historical S3 path needs its own ObjectStore so the plugin can
 # read it. Not used for ongoing backups — pure recovery-time config.
+# serverName=postgres17-v3 lives in the externalClusters[].plugin.parameters
+# of cluster17.yaml.
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
@@ -49,7 +56,6 @@ spec:
   configuration:
     destinationPath: s3://cloudnative-pg/
     endpointURL: https://s3.68cc.io
-    serverName: postgres17-v3
     s3Credentials:
       accessKeyId:
         name: cloudnative-pg-secret


### PR DESCRIPTION
Two issues post-merge of barman plugin migration (#381):

1. Flux ks 'cloudnative-pg-cluster' stuck in dry-run-failed loop: ObjectStore.spec.configuration.serverName: Forbidden: use the 'serverName' plugin parameter in the Cluster resource

   The plugin's webhook rejects serverName at the ObjectStore level — it lives on Cluster.spec.plugins[].parameters.serverName instead. Fix: drop serverName from both ObjectStore CRs (postgres17-v3 and postgres17-v4); add serverName to the Cluster's plugin parameters for both the live cluster (postgres17-v4) and the recovery source (postgres17-v3 in externalClusters).

   Same S3 path semantics: plugin reads/writes s3://cloudnative-pg/postgres17-v4/ as before. The ObjectStore now carries only the S3 location + creds + retention; per-cluster path differentiation is the cluster's job. This shape is what the official cluster-example.yaml in cnpg/plugin-barman-cloud demos.

   Live cluster's in-tree spec.backup.barmanObjectStore is still active because Flux never applied the new cluster17.yaml — backups continued working throughout the partial-merge state.

2. 'kubectl cnpg' command not found locally.

   Add kubectl-cnpg CLI plugin via mise/aqua: aqua:cloudnative-pg/cloudnative-pg/kubectl-cnpg = 1.29.1

   Tracks cnpg operator chart version (currently 1.29.1). Renovate auto-bump silently no-ops on this entry due to a 3-segment vs 2-segment depName mismatch (aqua identifier has the binary name as third segment; GitHub repo is 2 segments). Documented inline. Bump manually alongside the cnpg operator HelmRelease.

Server-side dry-run with --field-manager=kustomize-controller now clean for the cluster CR + both ObjectStore CRs.