### PR TITLE
feat(databases): cnpg image flavor system-trixie -> standard-trixie + plugin-aware backup alert

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/cluster/imagecatalog.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/imagecatalog.yaml
@@ -12,9 +12,18 @@
 # `cloudnative-pg/postgresql` Docker tag (see customManagers).
 #
 # OS distro: trixie (Debian 13). Migration history:
-#   - bullseye (Debian 11)  — initial cluster state
-#   - bookworm (Debian 12)  — PR feat/cnpg-imagecatalog-svc-alias
-#   - trixie   (Debian 13)  — this PR
+#   - bullseye (Debian 11) system   — initial cluster state
+#   - bookworm (Debian 12) system   — PR feat/cnpg-imagecatalog-svc-alias
+#   - trixie   (Debian 13) system   — PR feat/cnpg-distro-hop-trixie
+#   - trixie   (Debian 13) standard — this PR
+#
+# Image FLAVOR: standard (NOT system). The `system` flavor is deprecated
+# upstream (Sep 2025); ships barman binaries inline in the cluster pod
+# but is being removed. The `standard` flavor doesn't bundle barman —
+# the barman-cloud plugin operator (kubernetes/apps/databases/cnpg-barman-plugin/)
+# handles backups via a sidecar instead. PR 3 (feat/cnpg-barman-plugin)
+# moved cluster CR to spec.plugins[]; this PR drops the unused barman
+# binaries from the cluster pod itself.
 #
 # cnpg requires same-OS for in-place major upgrades:
 #   https://cloudnative-pg.io/docs/1.29/postgres_upgrades/
@@ -22,10 +31,10 @@
 # the PG major bump happens distro-stable.
 #
 # Catalog YAMLs in cnpg-postgres-containers ship only bookworm + bullseye
-# entries today, but the runtime images for trixie ARE published. We
-# pull digests directly from the registry. Verified via:
+# entries today, but the runtime images for trixie ARE published. Digests
+# pulled directly from the registry; verified via:
 #   curl -H "Authorization: Bearer <token>" \
-#     https://ghcr.io/v2/cloudnative-pg/postgresql/manifests/17.10-202605250923-system-trixie
+#     https://ghcr.io/v2/cloudnative-pg/postgresql/manifests/17.10-202605250923-standard-trixie
 apiVersion: postgresql.cnpg.io/v1
 kind: ClusterImageCatalog
 metadata:
@@ -34,7 +43,7 @@ spec:
   images:
     # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql versioning=loose
     - major: 17
-      image: ghcr.io/cloudnative-pg/postgresql:17.10-202605250923-system-trixie@sha256:66269150d761c0cef234eb5a0f6103851b948e043fe4080d9c0e758053c15356
+      image: ghcr.io/cloudnative-pg/postgresql:17.10-202605250923-standard-trixie@sha256:e89d5423983438428ceed39aef567bcc33e28160b6145fe09a40fb0a31a99e5b
     # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql versioning=loose
     - major: 18
-      image: ghcr.io/cloudnative-pg/postgresql:18.4-202605250923-system-trixie@sha256:47bd8dc5695a7f6f0189e205dfdb964aafbfafc337152c792ea62566edf75c33
+      image: ghcr.io/cloudnative-pg/postgresql:18.4-202605250923-standard-trixie@sha256:1e9b7f86a108b8eb472f52b59fc085aafee4cb3841484727ad67c020a8935a86

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/prometheusrule.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/prometheusrule.yaml
@@ -82,11 +82,20 @@ spec:
               frozen — check `kubectl get scheduledbackup -n databases` and
               compare nextScheduleTime vs now. Ref: home-ops-6cn.
             summary: CNPG base backup is stale
-          # Guard against the "never backed up" case where the metric is 0 —
-          # that produces a ~56-year delta and would fire on fresh clusters.
+          # Backup-timestamp source switched from in-tree
+          # `cnpg_collector_last_available_backup_timestamp` to the plugin's
+          # `barman_cloud_cloudnative_pg_io_last_available_backup_timestamp`
+          # in PR feat/cnpg-standard-flavor-and-plugin-alert. The cnpg
+          # collector's metric stays bound to in-tree state — primary
+          # reports 0 forever under plugin-managed backups, replica reports
+          # the last in-tree value frozen in time.
+          #
+          # `max by (cluster)` collapses the per-pod series so a single
+          # successful backup on either instance counts. Guard against the
+          # "never backed up" case (metric == 0) with the > 0 prefix.
           expr: |-
-            (cnpg_collector_last_available_backup_timestamp > 0)
-              and (time() - cnpg_collector_last_available_backup_timestamp > 48 * 3600)
+            (max by (job) (barman_cloud_cloudnative_pg_io_last_available_backup_timestamp) > 0)
+              and (time() - max by (job) (barman_cloud_cloudnative_pg_io_last_available_backup_timestamp) > 48 * 3600)
           for: 15m
           labels:
             severity: critical


### PR DESCRIPTION
Two coupled changes from the PG18 upgrade plan PR 4. Both required to keep observability accurate after the barman plugin migration in PR 3.

1. Image flavor swap (catalog digests):
   - 17.10-202605250923-system-trixie -> 17.10-202605250923-standard-trixie@sha256:e89d5...
   - 18.4-202605250923-system-trixie -> 18.4-202605250923-standard-trixie@sha256:1e9b7...

   The 'system' flavor is deprecated upstream (Sep 2025); ships barman
   binaries inline in the cluster pod. After PR 3 the plugin owns
   backups via a sidecar, so the in-pod barman binaries from 'system'
   are dead weight. 'standard' drops them; cnpg-barman-cloud sidecar
   container handles barman-cloud-* invocations.

   Expected impact on apply: rolling restart (~30s switchover). Replicas
   re-provision PVCs at the new image. Plugin keeps backing up
   throughout — backups are sidecar-driven, not bundled.

2. CNPGStaleBaseBackup alert metric source change: The cnpg collector's metric cnpg_collector_last_available_backup_timestamp reports in-tree barman state. Under plugin-managed backups it never updates on the primary (stays at 0) — the alert would fire ~48h after the last in-tree backup, which is today's 04:00 run. Verified live: postgres17-1 (replica): cnpg_collector...=1779768091 (yesterday's in-tree) postgres17-2 (primary): cnpg_collector...=0 (never had in-tree backup recorded)

   Plugin operator emits its own metric: barman_cloud_cloudnative_pg_io_last_available_backup_timestamp Both pods report the timestamp of the most recent plugin backup.

   Update CNPGStaleBaseBackup expr to use the plugin metric. Wrap with max by (job) to collapse per-pod series — a single successful backup anywhere in the cluster counts. Guard against the 'never backed up' case (metric == 0) with the > 0 prefix as before.

   WAL-archive alerts (LastFailedArchiveTime, CNPGWALArchiveBacklog) keep using cnpg_pg_stat_archiver_* — verified those metrics ARE updated by the plugin's archive_command (cnpg_pg_stat_archiver_last_archived_time reports recent timestamps from postgres17-1).

Soak window: standard-trixie roll soaks alongside the alert change. After tonight's @daily ScheduledBackup runs via plugin method, both the metric and the alert reflect plugin state end-to-end.