### PR TITLE
feat(databases): bump cnpg cluster PG17 -> PG18 + new ObjectStore postgres18-v1

### DIFF
--- a/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml
@@ -22,8 +22,8 @@ spec:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog
     name: postgresql
-    major: 17
-  description: "Shared PG17 Cluster"
+    major: 18
+  description: "Shared PG cluster"
   primaryUpdateStrategy: unsupervised
   # Exclude CNPG PVCs from Velero fs-backup — data is already shipped to
   # s3://cloudnative-pg via barmanObjectStore and PITR is driven from WAL
@@ -123,8 +123,15 @@ spec:
         # ObjectStore itself, so it has to live on the Cluster's plugin
         # parameters instead. Same ObjectStore CR could serve multiple
         # clusters with different per-cluster serverNames.
-        barmanObjectName: postgres17-v4
-        serverName: postgres17-v4
+        #
+        # Rotated postgres17-v4 -> postgres18-v1 at the PG18 cutover. New
+        # backups land at s3://cloudnative-pg/postgres18-v1/ — clean
+        # separation from the PG17 archives. PITR is invalid across
+        # major-version boundaries so a fresh path avoids ambiguity.
+        # postgres17-v4 ObjectStore still exists for forensic reference;
+        # its archive ages out under the existing 30d retention.
+        barmanObjectName: postgres18-v1
+        serverName: postgres18-v1
   # Recovery source for new instances bootstrapping from S3.
   # `externalClusters[].plugin` replaces the legacy `barmanObjectStore`
   # block — points at the postgres17-v3 ObjectStore CR + its own serverName.

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/imagecatalog.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/imagecatalog.yaml
@@ -15,7 +15,13 @@
 #   - bullseye (Debian 11) system   — initial cluster state
 #   - bookworm (Debian 12) system   — PR feat/cnpg-imagecatalog-svc-alias
 #   - trixie   (Debian 13) system   — PR feat/cnpg-distro-hop-trixie
-#   - trixie   (Debian 13) standard — this PR
+#   - trixie   (Debian 13) standard — PR feat/cnpg-standard-trixie
+#
+# PG version progression on this catalog:
+#   - PG 17.10 — initial entry; cluster used until PG18 cutover
+#   - PG 18.4  — current cluster target (PR feat/cnpg-pg18-bump)
+# Both stay in the catalog so a rollback to major: 17 remains a one-line
+# revert without re-resolving image digests.
 #
 # Image FLAVOR: standard (NOT system). The `system` flavor is deprecated
 # upstream (Sep 2025); ships barman binaries inline in the cluster pod

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/objectstore.yaml
@@ -63,3 +63,40 @@ spec:
       secretAccessKey:
         name: cloudnative-pg-secret
         key: S3_SECRET_ACCESS_KEY
+---
+# Post-PG18 backup target. Fresh serverName so PG18 backups land at
+# s3://cloudnative-pg/postgres18-v1/ — a clean directory separate from
+# the PG17 archives at s3://cloudnative-pg/postgres17-v4/. Rationale:
+# PITR is invalid across major-version boundaries (PG18 binaries can't
+# replay PG17 WAL), so mixing timelines in the same path is at best
+# confusing and at worst a footgun during recovery. Aligns with cnpg's
+# upstream upgrade docs example (postgres-cluster-pg16 -> -pg17).
+#
+# Migration sequencing:
+#   - This ObjectStore lands BEFORE the major bump (PR 5 of the upgrade
+#     plan) so the cluster CR can reference it atomically.
+#   - First plugin backup post-PG18 lands at the new path.
+#   - postgres17-v4 ObjectStore stays around as a forensic reference
+#     (its S3 archive ages out under the existing 30d retention).
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: postgres18-v1
+  namespace: databases
+spec:
+  configuration:
+    destinationPath: s3://cloudnative-pg/
+    endpointURL: https://s3.68cc.io
+    s3Credentials:
+      accessKeyId:
+        name: cloudnative-pg-secret
+        key: S3_ACCESS_KEY_ID
+      secretAccessKey:
+        name: cloudnative-pg-secret
+        key: S3_SECRET_ACCESS_KEY
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8
+  retentionPolicy: 30d


### PR DESCRIPTION
PR 5 of the cnpg upgrade plan. Major version bump from PG 17.10 to PG 18.4 on standard-trixie. Downtime expected: 5-15 min for ~1.5 GB across 12 databases on openebs-hostpath. cnpg runs pg_upgrade --link (hardlinks, no copy) so most of the window is pod orchestration + replica PVC re-provisioning, not data migration.

Changes:

1. cluster17.yaml: imageCatalogRef.major 17 -> 18
   description: 'Shared PG17 Cluster' -> 'Shared PG cluster'

2. cluster17.yaml: spec.plugins[].parameters barmanObjectName + serverName: postgres17-v4 -> postgres18-v1 New backups land at s3://cloudnative-pg/postgres18-v1/. Clean separation from PG17 archive lineage. PITR is invalid across major boundaries so a fresh path avoids any operator-side ambiguity during recovery. Aligns with cnpg upstream upgrade docs example (postgres-cluster-pg16 -> -pg17).

3. objectstore.yaml: NEW ObjectStore 'postgres18-v1' (alongside existing postgres17-v3 + postgres17-v4). Same S3 endpoint, same credentials, same compression + retention as predecessors. Lands in this PR before the major bump so the cluster CR can reference it atomically; ObjectStore + Cluster spec change apply together. postgres17-v4 stays around as a forensic reference (its archive ages out under the existing 30d retention).

4. imagecatalog.yaml: comment hygiene only — added PG version progression history. PG 17.10 entry stays in catalog so rollback is a one-line major: 18 -> 17 revert.

Pre-merge required:

  # Take a fresh plugin-driven backup against postgres17-v4 path
  TS=$(date +%Y%m%d%H%M%S)
  printf 'apiVersion: postgresql.cnpg.io/v1\nkind: Backup\nmetadata:\n  name: postgres17-pre-pg18-%s\n  namespace: databases\nspec:\n  cluster:\n    name: postgres17\n  method: plugin\n  pluginConfiguration:\n    name: barman-cloud.cloudnative-pg.io\n' "$TS" | kubectl create -f - --context home

  # Wait for completion + verify
  kubectl get backup -n databases --context home --sort-by=.metadata.creationTimestamp \
    -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,METHOD:.spec.method | tail -3
  aws --endpoint-url https://s3.68cc.io s3 ls s3://cloudnative-pg/postgres17-v4/base/ --recursive | tail -3

What happens after merge:
  1. Operator detects imageCatalogRef.major change.
  2. Stops cluster pods (writes blocked).
  3. Validates new image (PG18 trixie standard).
  4. pg_upgrade --link on the PGDATA.
  5. Replicas destroy + re-provision PVCs at PG18.
  6. Cluster comes back on PG18; first plugin-driven WAL archive lands at s3://cloudnative-pg/postgres18-v1/.
  7. Sidecar continues backups under postgres18-v1.

Manual post-merge (PR 6 in runbook):
  # 1. Confirm version
  kubectl exec -n databases postgres17-2 -c postgres --context home -- \
    psql -U postgres -tAc 'SELECT version();'

  # 2. ANALYZE every non-template DB (pg_upgrade doesn't transfer stats)
  for DB in $(kubectl exec -n databases postgres17-2 -c postgres --context home -- \
    psql -U postgres -tAc "SELECT datname FROM pg_database WHERE datistemplate=false AND datname<>'postgres'"); do
      kubectl exec -n databases postgres17-2 -c postgres --context home -- \
        psql -U postgres -d "$DB" -c 'ANALYZE VERBOSE'
  done

  # 3. Reset pg_stat_statements (counters meaningless across major boundary)
  kubectl exec -n databases postgres17-2 -c postgres --context home -- \
    psql -U postgres -c 'SELECT pg_stat_statements_reset()'

  # 4. Take fresh post-upgrade backup (lands in postgres18-v1)
  # ...same Backup CR as pre-merge but with -pg18-postupgrade- prefix

  # 5. Verify backup in NEW S3 path
  aws --endpoint-url https://s3.68cc.io s3 ls s3://cloudnative-pg/postgres18-v1/base/ --recursive

Rollback (if needed):
  Revert this PR. Operator resumes PG17 on the original PGDATA
  (cnpg's --link mode preserves it). spec.plugins[].parameters
  revert to postgres17-v4 — backups resume against the existing
  S3 path. New postgres18-v1 archive (if any landed) is orphaned
  but harmless.