### PR TITLE
feat(databases): bump cnpg cluster PG17 -> PG18 + new ObjectStore + rename to cluster.yaml

### DIFF
--- a/docs/runbooks/cnpg-barman-plugin-migration.md
+++ b/docs/runbooks/cnpg-barman-plugin-migration.md
@@ -104,7 +104,7 @@ spec:
       secretAccessKey: { name: cloudnative-pg-secret, key: S3_SECRET_ACCESS_KEY }
 ```
 
-### 3. Modify cluster17.yaml
+### 3. Modify cluster.yaml
 
 ```yaml
 spec:
@@ -178,7 +178,7 @@ Revert the commits. Backup data in S3 is **format-compatible** with both the in-
 
 ## Related
 
-- `kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml` — current Cluster CR (still in-tree)
+- `kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml` — current Cluster CR (still in-tree)
 - `kubernetes/apps/databases/cloudnative-pg/cluster/scheduledbackup.yaml` — current ScheduledBackup
-- `cluster17.yaml` `spec.bootstrap.recovery.source: postgres17-v3` — needs migration too
+- `cluster.yaml` `spec.bootstrap.recovery.source: postgres17-v3` — needs migration too
 - Memory: `project_cnpg_barman_plugin_migration` (deferred work tracker)

--- a/docs/runbooks/cnpg-major-upgrade.md
+++ b/docs/runbooks/cnpg-major-upgrade.md
@@ -128,7 +128,7 @@ aws --endpoint-url https://s3.68cc.io s3 ls s3://cloudnative-pg/postgres17-v4/ba
 + major: 18
 ```
 
-in `kubernetes/apps/databases/cloudnative-pg/cluster/cluster17.yaml`.
+in `kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml`.
 
 **What happens after merge:**
 
@@ -194,7 +194,7 @@ rtk kubectl cnpg backup postgres17 -n databases --context home
 |-------|----------|
 | Before PR 3 merge | Just don't merge. Catalog + aliases are inert. |
 | PR 3 merged but pg_upgrade hasn't completed | Revert the `major: 18 → 17` PR. Operator resumes the old version on the original PGDATA (cnpg's `--link` mode preserves it). |
-| pg_upgrade completed but consumers broken | Revert `major: 18 → 17`. Operator restores from the pre-upgrade backup taken in PR 3 prereq via `bootstrap.recovery`. **Bump `serverName` to `postgres17-v5`** in cluster17.yaml's `spec.backup.barmanObjectStore` so WAL archives don't collide with the old timeline. |
+| pg_upgrade completed but consumers broken | Revert `major: 18 → 17`. Operator restores from the pre-upgrade backup taken in PR 3 prereq via `bootstrap.recovery`. **Bump `serverName` to `postgres17-v5`** in cluster.yaml's `spec.backup.barmanObjectStore` so WAL archives don't collide with the old timeline. |
 | Disaster (data loss) | `bootstrap.recovery.source` from `postgres17-v4` (last pre-upgrade serverName) into a fresh cluster. ~1 GB recovery is fast. |
 
 ## Consumer migration to `postgres-rw` alias (opportunistic)

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/cluster.yaml
@@ -3,27 +3,26 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  # NOTE: metadata.name stays `postgres17` indefinitely. Renaming a cnpg
+  # Cluster CR is destructive — operator deletes/recreates the StatefulSet,
+  # drops PVCs, and forces a full restore from S3. The version stamp in
+  # the name is therefore a fossil that future-me cannot easily remove.
+  # Consumer-facing access uses the version-stable ExternalName Services
+  # in service-aliases.yaml (postgres-rw / -r / -ro).
   name: postgres17
 spec:
   instances: 2
   # Image is pinned via the ClusterImageCatalog `postgresql` (sibling
-  # imagecatalog.yaml, bookworm digests). To bump the major version,
-  # change `major:` to a value present in that catalog. Patch versions
-  # roll forward when the catalog itself is bumped (separate PR).
-  # Procedure: docs/runbooks/cnpg-major-upgrade.md.
-  #
-  # NOTE: imageName + imageCatalogRef are mutually exclusive at the
-  # cnpg webhook layer. If the live Cluster object still has imageName
-  # set (legacy state pre-this-PR), Flux's apply will fail validation.
-  # Pre-merge step (one-time, documented in runbook):
-  #   kubectl patch cluster postgres17 -n databases --context home \
-  #     --type=json -p='[{"op":"remove","path":"/spec/imageName"}]'
+  # imagecatalog.yaml, trixie standard digests). To bump the major
+  # version, change `major:` to a value present in that catalog. Patch
+  # versions roll forward when the catalog itself is bumped (separate
+  # PR). Procedure: docs/runbooks/cnpg-major-upgrade.md.
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog
     name: postgresql
-    major: 17
-  description: "Shared PG17 Cluster"
+    major: 18
+  description: "Shared PG cluster"
   primaryUpdateStrategy: unsupervised
   # Exclude CNPG PVCs from Velero fs-backup — data is already shipped to
   # s3://cloudnative-pg via barmanObjectStore and PITR is driven from WAL
@@ -121,10 +120,16 @@ spec:
         # credentials + retention. Path-within-bucket is set HERE via
         # `serverName` — the plugin's webhook rejects serverName on the
         # ObjectStore itself, so it has to live on the Cluster's plugin
-        # parameters instead. Same ObjectStore CR could serve multiple
-        # clusters with different per-cluster serverNames.
-        barmanObjectName: postgres17-v4
-        serverName: postgres17-v4
+        # parameters instead.
+        #
+        # Rotated postgres17-v4 -> postgres18-v1 at the PG18 cutover. New
+        # backups land at s3://cloudnative-pg/postgres18-v1/ — clean
+        # separation from the PG17 archives. PITR is invalid across major
+        # boundaries so a fresh path avoids ambiguity. postgres17-v4
+        # ObjectStore stays around as a forensic reference; its archive
+        # ages out under the existing 30d retention.
+        barmanObjectName: postgres18-v1
+        serverName: postgres18-v1
   # Recovery source for new instances bootstrapping from S3.
   # `externalClusters[].plugin` replaces the legacy `barmanObjectStore`
   # block — points at the postgres17-v3 ObjectStore CR + its own serverName.

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/imagecatalog.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/imagecatalog.yaml
@@ -15,7 +15,13 @@
 #   - bullseye (Debian 11) system   — initial cluster state
 #   - bookworm (Debian 12) system   — PR feat/cnpg-imagecatalog-svc-alias
 #   - trixie   (Debian 13) system   — PR feat/cnpg-distro-hop-trixie
-#   - trixie   (Debian 13) standard — this PR
+#   - trixie   (Debian 13) standard — PR feat/cnpg-standard-trixie
+#
+# PG version progression on this catalog:
+#   - PG 17.10 — initial entry; cluster ran on this until PG18 cutover
+#   - PG 18.4  — current cluster target (PR feat/cnpg-pg18-bump)
+# Both stay in the catalog so a rollback to major: 17 remains a one-line
+# revert without re-resolving image digests.
 #
 # Image FLAVOR: standard (NOT system). The `system` flavor is deprecated
 # upstream (Sep 2025); ships barman binaries inline in the cluster pod

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/kustomization.yaml
@@ -4,7 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./imagecatalog.yaml
-  - ./cluster17.yaml
+  - ./cluster.yaml
   - ./service-aliases.yaml
   - ./objectstore.yaml
   - ./scheduledbackup.yaml

--- a/kubernetes/apps/databases/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/databases/cloudnative-pg/cluster/objectstore.yaml
@@ -41,12 +41,12 @@ spec:
   # in the in-tree model).
   retentionPolicy: 30d
 ---
-# Recovery-source ObjectStore. cluster17.yaml's spec.bootstrap.recovery
+# Recovery-source ObjectStore. cluster.yaml's spec.bootstrap.recovery
 # references the original postgres17-v3 cluster (pre-current-incarnation).
 # That historical S3 path needs its own ObjectStore so the plugin can
 # read it. Not used for ongoing backups — pure recovery-time config.
 # serverName=postgres17-v3 lives in the externalClusters[].plugin.parameters
-# of cluster17.yaml.
+# of cluster.yaml.
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
@@ -63,3 +63,40 @@ spec:
       secretAccessKey:
         name: cloudnative-pg-secret
         key: S3_SECRET_ACCESS_KEY
+---
+# Post-PG18 backup target. Fresh serverName so PG18 backups land at
+# s3://cloudnative-pg/postgres18-v1/ — a clean directory separate from
+# the PG17 archives at s3://cloudnative-pg/postgres17-v4/. Rationale:
+# PITR is invalid across major-version boundaries (PG18 binaries can't
+# replay PG17 WAL), so mixing timelines in the same path is at best
+# confusing and at worst a footgun during recovery. Aligns with cnpg's
+# upstream upgrade docs example (postgres-cluster-pg16 -> -pg17).
+#
+# Migration sequencing:
+#   - This ObjectStore lands BEFORE the major bump (PR 5 of the upgrade
+#     plan) so the cluster CR can reference it atomically.
+#   - First plugin backup post-PG18 lands at the new path.
+#   - postgres17-v4 ObjectStore stays around as a forensic reference
+#     (its S3 archive ages out under the existing 30d retention).
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: postgres18-v1
+  namespace: databases
+spec:
+  configuration:
+    destinationPath: s3://cloudnative-pg/
+    endpointURL: https://s3.68cc.io
+    s3Credentials:
+      accessKeyId:
+        name: cloudnative-pg-secret
+        key: S3_ACCESS_KEY_ID
+      secretAccessKey:
+        name: cloudnative-pg-secret
+        key: S3_SECRET_ACCESS_KEY
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8
+  retentionPolicy: 30d


### PR DESCRIPTION
PR 5 of the cnpg upgrade plan. Bundles the major-version bump with the cosmetic rename that was originally PR 7 — both are non-destructive on the metadata.name field (which stays postgres17 by design; renaming the Cluster CR is destructive).

Major version bump (PG 17.10 -> PG 18.4 on standard-trixie):
  - cluster.yaml: imageCatalogRef.major 17 -> 18
  - description: 'Shared PG17 Cluster' -> 'Shared PG cluster'
  - spec.plugins[].parameters.barmanObjectName: postgres17-v4 -> postgres18-v1
  - spec.plugins[].parameters.serverName: postgres17-v4 -> postgres18-v1 New backups land at s3://cloudnative-pg/postgres18-v1/. Clean separation from PG17 archive lineage. PITR is invalid across major boundaries so a fresh path avoids any operator-side ambiguity during recovery. Aligns with cnpg upstream upgrade docs example (postgres-cluster-pg16 -> -pg17).

Cosmetic rename (originally PR 7):
  - cluster17.yaml -> cluster.yaml (git mv preserves history)
  - kustomization.yaml resources entry updated
  - Header comment in cluster.yaml documents that metadata.name stays postgres17 forever — renaming the Cluster CR drops the StatefulSet and forces a full S3 restore. The version stamp in the K8s name is a fossil; consumer-facing access uses the postgres-{rw,r,ro} ExternalName aliases for version-stable connectivity.
  - imagecatalog.yaml header: PG version progression note added so rollback expectations stay clear.
  - Docs (cnpg-major-upgrade.md, cnpg-barman-plugin-migration.md) updated to reference cluster.yaml.

NEW ObjectStore postgres18-v1:
  Same S3 endpoint, same credentials, same compression + retention as
  postgres17-v4. Lands BEFORE the major bump applies so the cluster CR
  reference is atomic. postgres17-v4 ObjectStore retained as forensic
  reference; its archive ages out under the existing 30d retention.

Pre-merge required (manual):
  TS=$(date +%Y%m%d%H%M%S)
  printf 'apiVersion: postgresql.cnpg.io/v1\nkind: Backup\nmetadata:\n  name: postgres17-pre-pg18-%s\n  namespace: databases\nspec:\n  cluster:\n    name: postgres17\n  method: plugin\n  pluginConfiguration:\n    name: barman-cloud.cloudnative-pg.io\n' "$TS" | kubectl create -f - --context home
  kubectl get backup -n databases --context home --sort-by=.metadata.creationTimestamp -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,METHOD:.spec.method | tail -3
  aws --endpoint-url https://s3.68cc.io s3 ls s3://cloudnative-pg/postgres17-v4/base/ --recursive | tail -3

Reconcile mechanics on merge:
  1. Operator detects imageCatalogRef.major change.
  2. Stops cluster pods (writes blocked).
  3. Validates new image (PG18 trixie standard).
  4. pg_upgrade --link on the PGDATA (sub-second per DB; hardlinks).
  5. Replicas destroy + re-provision PVCs at PG18.
  6. Cluster boots on PG18; first plugin-driven WAL archive lands at s3://cloudnative-pg/postgres18-v1/.
  7. Backups continue via plugin under postgres18-v1.

Manual post-merge (PR 6 in runbook):
  - SELECT version() to confirm 18.4
  - ANALYZE every non-template DB (pg_upgrade doesn't transfer stats)
  - SELECT pg_stat_statements_reset() (counters meaningless across boundary)
  - Take fresh post-upgrade backup, verify in postgres18-v1 S3 path

Rollback (if needed):
  Revert this PR. cnpg's pg_upgrade --link preserves original PGDATA;
  reverting major: 18 -> 17 restores PG17. spec.plugins[].parameters
  revert to postgres17-v4. Any orphaned postgres18-v1 archive is
  harmless and ages out per its 30d retention.