### PR TITLE
chore: replace google-oidc-secure with authentik-forwardauth in stale comments

### DIFF
--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -44,7 +44,7 @@ spec:
       # tunnel hostname. cloudflared (kubernetes/apps/network/cloudflared)
       # runs the tunnel in-cluster; the tunnel's public ingress config
       # forwards *.68cc.io to traefik-external.network.svc:443 where
-      # Traefik + the google-oidc-secure middleware take over.
+      # Traefik + the authentik-forwardauth middleware take over.
       #
       # --force-default-targets overrides each route's
       # external-dns.alpha.kubernetes.io/target annotation (which stays

--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -7,7 +7,7 @@
 # Cloudflare dashboard / API (not via this repo) — the tunnel config
 # points every *.68cc.io hostname at
 # traefik-external.network.svc.cluster.local:443, where Traefik + the
-# google-oidc-secure middleware (traefikoidc plugin) take over.
+# authentik-forwardauth middleware takes over.
 #
 # Phase 1 of the Cloudflare tunnel rollout. See CLAUDE.md + the
 # accompanying PR for the architecture write-up.

--- a/kubernetes/apps/services/homebridge/app/helmrelease.yaml
+++ b/kubernetes/apps/services/homebridge/app/helmrelease.yaml
@@ -97,15 +97,15 @@ spec:
           - name: traefik-internal-gateway
             namespace: network
         rules:
-          # OIDC opt-in: uncomment to gate behind Google sign-in via the
-          # traefikoidc plugin. Currently disabled — Homebridge UI uses
-          # its own session auth and HAP traffic is bearer-token only.
+          # Auth opt-in: uncomment to gate behind Authentik.
+          # Currently disabled — Homebridge UI uses its own session auth
+          # and HAP traffic is bearer-token only.
           # - filters:
           #     - type: ExtensionRef
           #       extensionRef:
           #         group: traefik.io
           #         kind: Middleware
-          #         name: google-oidc-secure
+          #         name: authentik-forwardauth
           - backendRefs:
               - name: *app
                 port: *port


### PR DESCRIPTION
Three files had leftover references to the old traefikoidc plugin name (google-oidc-secure) in comments. No live route filters were affected — all routes already used authentik-forwardauth. Pure comment hygiene to avoid copy-paste confusion when adding future routes.