### PR TITLE
feat(services,ai): re-enable Paperless-ngx + home-ops RAG workflows

### DIFF
--- a/docs/runbooks/dragonflydb-db-allocation.md
+++ b/docs/runbooks/dragonflydb-db-allocation.md
@@ -19,7 +19,7 @@ This file is the source of truth for DB allocation. Update it when adding or rem
 |----|----------|------------------|---------|-----------|
 | 0 | _(do not assign)_ | — | Default selection on connect; some clients touch it before `SELECT N`. Treat as transient — do NOT store data here. No consumer should target it. | — |
 | 1 | _free_ | — | _(stub registry previously claimed Traefik OIDC; verified WRONG — OIDC actually lives on db 5)_ | — |
-| 2 | _free_ | — | _(stub registry previously claimed Grafana; verified WRONG — Grafana has no Redis backend in this cluster)_ | — |
+| 2 | Paperless-ngx | `services/paperless` | Celery task broker + result backend (document processing, OCR jobs). Redis URL: `redis://...:6379/2`. | `kubernetes/apps/services/paperless/app/helmrelease.yaml` |
 | 3 | _free_ | — | — | — |
 | 4 | LiteLLM | `ai/litellm` | Response cache (per-request key, TTL 600s). Default key prefix. | `kubernetes/apps/ai/litellm/app/{configmap,helmrelease,secret.sops}.yaml` |
 | 5 | _(retired)_ | — | Previously: traefikoidc plugin OIDC session store (key prefix `traefikoidc:google:`). Plugin replaced by Authentik forwardAuth (2026-05-21). DB 5 is now free — no consumer. | — |

--- a/kubernetes/apps/ai/n8n/workflows/home-ops-full-resync.json
+++ b/kubernetes/apps/ai/n8n/workflows/home-ops-full-resync.json
@@ -1,0 +1,226 @@
+{
+  "name": "home-ops → AnythingLLM Full Resync",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "url": "https://api.github.com/repos/j0sh3rs/home-ops/git/trees/main?recursive=1",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Accept", "value": "application/vnd.github+json" },
+            { "name": "X-GitHub-Api-Version", "value": "2022-11-28" }
+          ]
+        },
+        "options": {}
+      },
+      "id": "fetch-repo-tree",
+      "name": "Fetch Repo Tree",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [460, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "github-token",
+          "name": "GitHub Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Filter the full repo tree to only the files we care about.\n// md: CLAUDE.md, docs/**/*.md\n// yaml: kubernetes/**/kustomization.yaml, kubernetes/**/helmrelease.yaml\nconst tree = $input.first().json.tree || [];\n\nconst isMdDoc = f =>\n  f === 'CLAUDE.md' ||\n  (f.startsWith('docs/') && f.endsWith('.md'));\n\nconst isYamlManifest = f =>\n  (f.startsWith('kubernetes/') || f.startsWith('talos/')) &&\n  (f.endsWith('kustomization.yaml') || f.endsWith('helmrelease.yaml'));\n\nconst items = [];\nfor (const entry of tree) {\n  if (entry.type !== 'blob') continue;\n  const file = entry.path;\n  if (isMdDoc(file)) {\n    items.push({ json: { fileType: 'md', file, sha: entry.sha } });\n  } else if (isYamlManifest(file)) {\n    items.push({ json: { fileType: 'yaml', file, sha: entry.sha } });\n  }\n}\n\nconsole.log(`Full resync: ${items.length} files to process (${items.filter(i=>i.json.fileType==='md').length} md, ${items.filter(i=>i.json.fileType==='yaml').length} yaml)`);\nreturn items;"
+      },
+      "id": "filter-target-files",
+      "name": "Filter Target Files",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/j0sh3rs/home-ops/contents/{{ $json.file }}?ref=main",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Accept", "value": "application/vnd.github.raw+json" },
+            { "name": "X-GitHub-Api-Version", "value": "2022-11-28" }
+          ]
+        },
+        "options": {
+          "response": { "response": { "responseFormat": "text" } }
+        }
+      },
+      "id": "fetch-file-content",
+      "name": "Fetch File Content",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "github-token",
+          "name": "GitHub Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Re-attach file metadata from the upstream item and hold raw content.\nconst raw = $input.item.json;\nconst rawContent = typeof raw === 'string' ? raw : (raw.data || raw.body || JSON.stringify(raw));\n\nconst fileType = $('Filter Target Files').item.json.fileType;\nconst file = $('Filter Target Files').item.json.file;\n\nreturn [{ json: { rawContent, fileType, file } }];"
+      },
+      "id": "attach-metadata",
+      "name": "Attach Metadata",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "type-is-yaml",
+              "leftValue": "={{ $json.fileType }}",
+              "rightValue": "yaml",
+              "operator": { "type": "string", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "route-md-vs-yaml",
+      "name": "MD or YAML?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract comments and key metadata from YAML manifests.\nconst { rawContent, file } = $json;\n\nconst lines = rawContent.split('\\n');\nconst comments = lines\n  .filter(l => l.trim().startsWith('#'))\n  .map(l => l.trim().replace(/^#+\\s?/, ''));\n\nconst extract = (pattern) => {\n  const m = rawContent.match(pattern);\n  return m ? m[1].trim() : null;\n};\n\nconst kind = extract(/^kind:\\s*(.+)/m);\nconst name = extract(/^  name:\\s*(.+)/m) || extract(/^name:\\s*(.+)/m);\nconst namespace = extract(/^  namespace:\\s*(.+)/m) || extract(/^namespace:\\s*(.+)/m);\nconst chart = extract(/(?:chart|url):\\s*oci:\\/\\/([^\\s]+)/m);\nconst imageRepo = extract(/repository:\\s*([^\\s]+)/m);\nconst imageTag = extract(/tag:\\s*([^\\s]+)/m);\n\nconst title = [kind, name].filter(Boolean).join(' / ') || file.replace(/^.*\\//, '').replace(/\\.yaml$/, '');\n\nconst sections = [\n  `# ${title}`,\n  ``,\n  `**File:** \\`${file}\\``,\n  kind ? `**Kind:** ${kind}` : null,\n  name ? `**Name:** ${name}` : null,\n  namespace ? `**Namespace:** ${namespace}` : null,\n  chart ? `**Chart:** ${chart}` : null,\n  (imageRepo && imageTag) ? `**Image:** ${imageRepo}:${imageTag}` : null,\n  ``,\n];\n\nif (comments.length > 0) {\n  sections.push(`## Comments / Intent`);\n  sections.push(``);\n  sections.push(...comments.map(c => `- ${c}`));\n  sections.push(``);\n}\n\nconst textContent = sections.filter(l => l !== null).join('\\n');\n\nreturn [{ json: { textContent, title, file } }];"
+      },
+      "id": "format-yaml-document",
+      "name": "Format YAML Document",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1560, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Pass markdown content through; derive title from first heading or filename.\nconst { rawContent, file } = $json;\n\nconst firstLine = rawContent.split('\\n')[0]?.trim() || '';\nconst titleFromHeading = firstLine.startsWith('#') ? firstLine.replace(/^#+\\s*/, '') : '';\nconst titleFromPath = file.replace(/^.*\\//, '').replace(/\\.md$/, '');\nconst title = titleFromHeading || titleFromPath;\n\nreturn [{ json: { textContent: rawContent, title, file } }];"
+      },
+      "id": "format-md-document",
+      "name": "Format MD Document",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1560, 400]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://anythingllm.ai.svc.cluster.local:3001/api/v1/document/raw-text",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "textContent",
+              "value": "={{ $json.textContent }}"
+            },
+            {
+              "name": "addToWorkspaces",
+              "value": "home-ops"
+            },
+            {
+              "name": "metadata",
+              "value": "={{ JSON.stringify({ title: $json.title, source: 'home-ops-repo', file: $json.file, syncedAt: new Date().toISOString() }) }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "push-to-anythingllm",
+      "name": "Push to AnythingLLM",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1780, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "anythingllm-api",
+          "name": "AnythingLLM API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const results = $input.all();\nconsole.log(`Full resync complete. Pushed ${results.length} document(s) to AnythingLLM workspace 'home-ops'.`);\nreturn [{ json: { status: 'ok', pushed: results.length, completedAt: new Date().toISOString() } }];"
+      },
+      "id": "done",
+      "name": "Done",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2000, 300]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [[{ "node": "Fetch Repo Tree", "type": "main", "index": 0 }]]
+    },
+    "Fetch Repo Tree": {
+      "main": [[{ "node": "Filter Target Files", "type": "main", "index": 0 }]]
+    },
+    "Filter Target Files": {
+      "main": [[{ "node": "Fetch File Content", "type": "main", "index": 0 }]]
+    },
+    "Fetch File Content": {
+      "main": [[{ "node": "Attach Metadata", "type": "main", "index": 0 }]]
+    },
+    "Attach Metadata": {
+      "main": [[{ "node": "MD or YAML?", "type": "main", "index": 0 }]]
+    },
+    "MD or YAML?": {
+      "main": [
+        [{ "node": "Format YAML Document", "type": "main", "index": 0 }],
+        [{ "node": "Format MD Document", "type": "main", "index": 0 }]
+      ]
+    },
+    "Format YAML Document": {
+      "main": [[{ "node": "Push to AnythingLLM", "type": "main", "index": 0 }]]
+    },
+    "Format MD Document": {
+      "main": [[{ "node": "Push to AnythingLLM", "type": "main", "index": 0 }]]
+    },
+    "Push to AnythingLLM": {
+      "main": [[{ "node": "Done", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "meta": {
+    "templateCredsSetupCompleted": false,
+    "instanceId": "home-ops"
+  },
+  "tags": [
+    { "name": "rag" },
+    { "name": "home-ops" },
+    { "name": "anythingllm" },
+    { "name": "github" }
+  ]
+}

--- a/kubernetes/apps/ai/n8n/workflows/home-ops-webhook-sync.json
+++ b/kubernetes/apps/ai/n8n/workflows/home-ops-webhook-sync.json
@@ -1,0 +1,276 @@
+{
+  "name": "home-ops → AnythingLLM Webhook Sync",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "home-ops-github-push",
+        "responseMode": "onReceived",
+        "responseData": "firstEntryJson",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "GitHub Push Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "home-ops-github-push"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate this is a push to main and extract changed/removed files.\n// GitHub delivers commits[].added, commits[].modified, commits[].removed.\nconst payload = $input.first().json.body || $input.first().json;\n\nconst ref = payload.ref || '';\nif (ref !== 'refs/heads/main') {\n  console.log(`Skipping push to non-main ref: ${ref}`);\n  return [];\n}\n\nconst beforeSha = payload.before;\nconst afterSha = payload.after;\nconst repoFullName = payload.repository?.full_name || 'j0sh3rs/home-ops';\n\nconst changedFiles = new Set();\nconst removedFiles = new Set();\n\nfor (const commit of (payload.commits || [])) {\n  for (const f of (commit.added || [])) changedFiles.add(f);\n  for (const f of (commit.modified || [])) changedFiles.add(f);\n  for (const f of (commit.removed || [])) {\n    removedFiles.add(f);\n    changedFiles.delete(f);\n  }\n}\n\nconst isMdDoc = f =>\n  f === 'CLAUDE.md' ||\n  f.startsWith('docs/runbooks/') && f.endsWith('.md') ||\n  f.startsWith('docs/research/') && f.endsWith('.md') ||\n  f.startsWith('docs/') && f.endsWith('.md');\n\nconst isYamlManifest = f =>\n  (f.startsWith('kubernetes/') || f.startsWith('talos/')) &&\n  (f.endsWith('kustomization.yaml') || f.endsWith('helmrelease.yaml'));\n\nconst items = [];\n\nfor (const file of changedFiles) {\n  if (isMdDoc(file)) {\n    items.push({ json: { fileType: 'md', file, repoFullName, afterSha, action: 'upsert' } });\n  } else if (isYamlManifest(file)) {\n    items.push({ json: { fileType: 'yaml', file, repoFullName, afterSha, action: 'upsert' } });\n  }\n}\n\nfor (const file of removedFiles) {\n  if (isMdDoc(file) || isYamlManifest(file)) {\n    items.push({ json: { fileType: 'deleted', file, repoFullName, afterSha, action: 'delete' } });\n  }\n}\n\nconsole.log(`Push to main: ${items.filter(i=>i.json.action==='upsert').length} to upsert, ${items.filter(i=>i.json.action==='delete').length} to delete`);\nreturn items;"
+      },
+      "id": "parse-push-payload",
+      "name": "Parse Push Payload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "action-is-upsert",
+              "leftValue": "={{ $json.action }}",
+              "rightValue": "upsert",
+              "operator": { "type": "string", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "route-upsert-vs-delete",
+      "name": "Upsert or Delete?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{ $json.repoFullName }}/contents/{{ $json.file }}?ref={{ $json.afterSha }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Accept", "value": "application/vnd.github.raw+json" },
+            { "name": "X-GitHub-Api-Version", "value": "2022-11-28" }
+          ]
+        },
+        "options": {
+          "response": { "response": { "responseFormat": "text" } }
+        }
+      },
+      "id": "fetch-file-content",
+      "name": "Fetch File from GitHub",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "github-token",
+          "name": "GitHub Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Merge file metadata (from the parse node, two items back) with raw content.\n// In n8n, after an HTTP Request node the previous item context is carried in $input.\n// We re-attach metadata from the upstream item via pairedItem.\nconst raw = $input.item.json;\nconst meta = $input.item.pairedItem;\n\n// The HTTP Request with text response puts the body in `data` when responseFormat=text.\n// Fall back gracefully.\nconst rawContent = typeof raw === 'string' ? raw : (raw.data || raw.body || JSON.stringify(raw));\n\n// Re-attach routing metadata from the paired upstream item.\nconst fileType = $('Parse Push Payload').item.json.fileType;\nconst file = $('Parse Push Payload').item.json.file;\n\nreturn [{ json: { rawContent, fileType, file } }];"
+      },
+      "id": "attach-file-metadata",
+      "name": "Attach File Metadata",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "type-is-yaml",
+              "leftValue": "={{ $json.fileType }}",
+              "rightValue": "yaml",
+              "operator": { "type": "string", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "route-md-vs-yaml",
+      "name": "MD or YAML?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1340, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// For Markdown docs: pass content through with title derived from file path.\n// Strips leading # from first heading if present.\nconst { rawContent, file } = $json;\n\nconst firstLine = rawContent.split('\\n')[0]?.trim() || '';\nconst titleFromHeading = firstLine.startsWith('#') ? firstLine.replace(/^#+\\s*/, '') : '';\nconst titleFromPath = file.replace(/^.*\\//, '').replace(/\\.md$/, '');\nconst title = titleFromHeading || titleFromPath;\n\nreturn [{ json: { textContent: rawContent, title, file } }];"
+      },
+      "id": "format-md-document",
+      "name": "Format MD Document",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1560, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// For YAML manifests: extract comments + kind/name/namespace metadata.\n// Comments (lines starting with #) often contain intent and context.\nconst { rawContent, file } = $json;\n\nconst lines = rawContent.split('\\n');\nconst comments = lines\n  .filter(l => l.trim().startsWith('#'))\n  .map(l => l.trim().replace(/^#+\\s?/, ''));\n\n// Extract key metadata fields via simple regex scan (not a full YAML parse).\nconst extract = (pattern) => {\n  const m = rawContent.match(pattern);\n  return m ? m[1].trim() : null;\n};\n\nconst kind = extract(/^kind:\\s*(.+)/m);\nconst name = extract(/^  name:\\s*(.+)/m) || extract(/^name:\\s*(.+)/m);\nconst namespace = extract(/^  namespace:\\s*(.+)/m) || extract(/^namespace:\\s*(.+)/m);\nconst chart = extract(/(?:chart|url):\\s*oci:\\/\\/([^\\s]+)/m);\nconst imageRepo = extract(/repository:\\s*([^\\s]+)/m);\nconst imageTag = extract(/tag:\\s*([^\\s]+)/m);\n\nconst title = [kind, name].filter(Boolean).join(' / ') || file.replace(/^.*\\//, '').replace(/\\.yaml$/, '');\n\nconst sections = [\n  `# ${title}`,\n  ``,\n  `**File:** \\`${file}\\``,\n  kind ? `**Kind:** ${kind}` : null,\n  name ? `**Name:** ${name}` : null,\n  namespace ? `**Namespace:** ${namespace}` : null,\n  chart ? `**Chart:** ${chart}` : null,\n  (imageRepo && imageTag) ? `**Image:** ${imageRepo}:${imageTag}` : null,\n  ``,\n];\n\nif (comments.length > 0) {\n  sections.push(`## Comments / Intent`);\n  sections.push(``),\n  sections.push(...comments.map(c => `- ${c}`));\n  sections.push(``);\n}\n\nconst textContent = sections.filter(l => l !== null).join('\\n');\n\nreturn [{ json: { textContent, title, file } }];"
+      },
+      "id": "format-yaml-document",
+      "name": "Format YAML Document",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1560, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://anythingllm.ai.svc.cluster.local:3001/api/v1/document/raw-text",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "textContent",
+              "value": "={{ $json.textContent }}"
+            },
+            {
+              "name": "addToWorkspaces",
+              "value": "home-ops"
+            },
+            {
+              "name": "metadata",
+              "value": "={{ JSON.stringify({ title: $json.title, source: 'home-ops-repo', file: $json.file, syncedAt: new Date().toISOString() }) }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "push-to-anythingllm",
+      "name": "Push to AnythingLLM",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1780, 200],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "anythingllm-api",
+          "name": "AnythingLLM API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build the document title the same way as upsert so the DELETE matches.\nconst { file } = $json;\nconst titleFromPath = file.replace(/^.*\\//, '').replace(/\\.(md|yaml)$/, '');\nreturn [{ json: { deleteTitle: titleFromPath, file } }];"
+      },
+      "id": "build-delete-title",
+      "name": "Build Delete Title",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 440]
+    },
+    {
+      "parameters": {
+        "method": "DELETE",
+        "url": "=http://anythingllm.ai.svc.cluster.local:3001/api/v1/document/{{ encodeURIComponent($json.deleteTitle) }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {
+          "response": { "response": { "neverError": true } }
+        }
+      },
+      "id": "delete-from-anythingllm",
+      "name": "Delete from AnythingLLM",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 440],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "anythingllm-api",
+          "name": "AnythingLLM API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const results = $input.all();\nconsole.log(`Sync complete. Processed ${results.length} item(s).`);\nreturn [{ json: { status: 'ok', processed: results.length, completedAt: new Date().toISOString() } }];"
+      },
+      "id": "done",
+      "name": "Done",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2000, 300]
+    }
+  ],
+  "connections": {
+    "GitHub Push Webhook": {
+      "main": [[{ "node": "Parse Push Payload", "type": "main", "index": 0 }]]
+    },
+    "Parse Push Payload": {
+      "main": [[{ "node": "Upsert or Delete?", "type": "main", "index": 0 }]]
+    },
+    "Upsert or Delete?": {
+      "main": [
+        [{ "node": "Fetch File from GitHub", "type": "main", "index": 0 }],
+        [{ "node": "Build Delete Title", "type": "main", "index": 0 }]
+      ]
+    },
+    "Fetch File from GitHub": {
+      "main": [[{ "node": "Attach File Metadata", "type": "main", "index": 0 }]]
+    },
+    "Attach File Metadata": {
+      "main": [[{ "node": "MD or YAML?", "type": "main", "index": 0 }]]
+    },
+    "MD or YAML?": {
+      "main": [
+        [{ "node": "Format YAML Document", "type": "main", "index": 0 }],
+        [{ "node": "Format MD Document", "type": "main", "index": 0 }]
+      ]
+    },
+    "Format YAML Document": {
+      "main": [[{ "node": "Push to AnythingLLM", "type": "main", "index": 0 }]]
+    },
+    "Format MD Document": {
+      "main": [[{ "node": "Push to AnythingLLM", "type": "main", "index": 0 }]]
+    },
+    "Push to AnythingLLM": {
+      "main": [[{ "node": "Done", "type": "main", "index": 0 }]]
+    },
+    "Build Delete Title": {
+      "main": [
+        [{ "node": "Delete from AnythingLLM", "type": "main", "index": 0 }]
+      ]
+    },
+    "Delete from AnythingLLM": {
+      "main": [[{ "node": "Done", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "meta": {
+    "templateCredsSetupCompleted": false,
+    "instanceId": "home-ops"
+  },
+  "tags": [
+    { "name": "rag" },
+    { "name": "home-ops" },
+    { "name": "anythingllm" },
+    { "name": "github" }
+  ]
+}

--- a/kubernetes/apps/services/kustomization.yaml
+++ b/kubernetes/apps/services/kustomization.yaml
@@ -18,13 +18,7 @@ resources:
   #  ./memos/ks.yaml
   - ./metamcp/ks.yaml
   - ./mosquitto/ks.yaml
-  # n8n, llama-swap, open-webui moved to the ai namespace; LiteLLM gateway
-  # was added there as a unified OpenAI-compatible front door for local +
-  # cloud LLMs. See kubernetes/apps/ai/.
-  #  - ./n8n/ks.yaml
-  #  - ./llama-swap/ks.yaml
-  #  - ./open-webui/ks.yaml
-  #  - ./paperless/ks.yaml
+  - ./paperless/ks.yaml
   - ./tetragon-policies/ks.yaml
 
 # home-assistant needs hostNetwork=true for mDNS/UPnP device auto-discovery.

--- a/kubernetes/apps/services/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/services/paperless/app/helmrelease.yaml
@@ -26,8 +26,9 @@ spec:
         initContainers:
           init-db:
             image:
-              repository: ghcr.io/onedr0p/postgres-init
-              tag: 17
+              repository: ghcr.io/home-operations/postgres-init
+              # Tracks the PG major version of the shared CNPG cluster.
+              tag: "18"
             envFrom:
               - secretRef:
                   name: paperless-secrets
@@ -40,10 +41,10 @@ spec:
             env:
               PAPERLESS_URL: "https://paperless.68cc.io"
               PAPERLESS_PORT: "8000"
-              # DragonflyDB now requires AUTH. Password injected via env-var
-              # (DRAGONFLYDB_PASSWORD) from the reflected dragonflydb-auth
-              # Secret; URL expansion happens at container start.
-              PAPERLESS_REDIS: "redis://:$(DRAGONFLYDB_PASSWORD)@dragonflydb.databases.svc.cluster.local:6379"
+              # DragonflyDB auth. Password from reflected dragonflydb-auth
+              # Secret. DB 2 is the Paperless allocation per
+              # docs/runbooks/dragonflydb-db-allocation.md.
+              PAPERLESS_REDIS: "redis://:$(DRAGONFLYDB_PASSWORD)@dragonflydb.databases.svc.cluster.local:6379/2"
               DRAGONFLYDB_PASSWORD:
                 secretKeyRef:
                   name: dragonflydb-auth
@@ -65,6 +66,13 @@ spec:
               PAPERLESS_EXPORT_DIR: "/usr/src/paperless/export"
               # Consumer settings
               PAPERLESS_CONSUMER_POLLING: "60"
+              # ── Gmail IMAP email consumption ──────────────────────────────
+              # Paperless polls the IMAP inbox on the schedule below and
+              # imports each email + attachments as a document. Uses an App
+              # Password (not your main Google password). The App Password
+              # and email address are injected from paperless-secrets.
+              # Generate at: https://myaccount.google.com/apppasswords
+              PAPERLESS_EMAIL_TASK_CRON: "*/10 * * * *"
             envFrom:
               - secretRef:
                   name: paperless-secrets
@@ -107,7 +115,6 @@ spec:
               # renovate: datasource=docker depName=gotenberg/gotenberg
               tag: 8.32.0
             env:
-              # Disable unnecessary modules
               DISABLE_GOOGLE_CHROME: "1"
             resources:
               requests:
@@ -129,10 +136,6 @@ spec:
         containers:
           app:
             image:
-              # Upstream paperless-ngx docker-compose pulls docker.io/apache/tika.
-              # The previous ghcr.io/paperless-ngx/tika repo does not exist —
-              # there is no fork; paperless just runs vanilla apache/tika.
-              # Tag scheme is `<tika>.<server>` (e.g. 2.9.1.0), NOT hyphenated.
               repository: apache/tika
               # renovate: datasource=docker depName=apache/tika
               tag: 3.3.1.0
@@ -152,19 +155,16 @@ spec:
                 enabled: false
 
     service:
-      # Primary service for the web UI
       app:
         controller: paperless
         ports:
           http:
             port: &port 8000
-      # Internal service for Gotenberg (Office→PDF)
       gotenberg:
         controller: gotenberg
         ports:
           http:
             port: 3000
-      # Internal service for Tika (text extraction)
       tika:
         controller: tika
         ports:
@@ -180,12 +180,17 @@ spec:
           - name: traefik-external-gateway
             namespace: network
         rules:
-          - backendRefs:
+          - filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: authentik-forwardauth
+            backendRefs:
               - name: *app
                 port: *port
 
     persistence:
-      # Application data (search index, classification models)
       data:
         type: persistentVolumeClaim
         storageClass: openebs-hostpath
@@ -197,7 +202,6 @@ spec:
             app:
               - path: /usr/src/paperless/data
 
-      # Scanned documents and thumbnails — size generously
       media:
         type: persistentVolumeClaim
         storageClass: openebs-hostpath
@@ -209,7 +213,6 @@ spec:
             app:
               - path: /usr/src/paperless/media
 
-      # Watch folder: drop files here to trigger ingest
       consume:
         type: persistentVolumeClaim
         storageClass: openebs-hostpath
@@ -221,7 +224,6 @@ spec:
             app:
               - path: /usr/src/paperless/consume
 
-      # Bulk export directory
       export:
         type: persistentVolumeClaim
         storageClass: openebs-hostpath

--- a/kubernetes/apps/services/paperless/app/secret.sops.yaml
+++ b/kubernetes/apps/services/paperless/app/secret.sops.yaml
@@ -3,46 +3,46 @@ kind: Secret
 metadata:
   name: paperless-secrets
 stringData:
-  PAPERLESS_SECRET_KEY: ENC[AES256_GCM,data:zrGNummFKbbzYVg/5gE7IHDjEJAcSWdD9QPV4ojXXO/KMUObOiJo/uejyZPglVcFuVLXScYLOPSKKubtcbr7Yl5DwPBlzggyYNmzLKGJK+Uz+rrrOma7TRnOQSu+eie8CeVlzqzKc4mhWwmvnEk1KcAqZN87HpU4W7+jEg==,iv:fEg9K9Yg+x+YaI29rpvgFY3K3b+7PEryGdJICV86LZY=,tag:BHLIFi8157XWptSLZzCH9g==,type:str]
-  #ENC[AES256_GCM,data:rQG2LUqKCw2lGUe6sQD3yHaW+xTj6E5wIJj0CDUpedD1UefdR9SF19DtlVrPLBz7nX0W2qbpVXBxcNHbhuy7VxZhwe4FpvA+,iv:eeQ30HxZEGKlQyO7B9cJnCqwz/S4/8IVvkD0fuFG9Fc=,tag:H8rj9PujciOdlx3gUVyxAA==,type:comment]
-  PAPERLESS_DBHOST: ENC[AES256_GCM,data:e0EDqAKb2bqDlNK5Vi8P2/ub25dFHy/COtp8UD4dOC2n/T2d96T+,iv:OEfIdL78gLuiP0A75NfvtdYPtgEgulrPKoDFnlBNI20=,tag:nsDbgqjcPPHWlxmC6Y2yGQ==,type:str]
-  PAPERLESS_DBNAME: ENC[AES256_GCM,data:eGuJyu95Zrkn,iv:/hZdaXh2WfS1WdDVbxjtVr1LOYbln99ub/RcoRFkpz8=,tag:av7ylm+0dnM2e2HOd43PEQ==,type:str]
-  PAPERLESS_DBUSER: ENC[AES256_GCM,data:97s6WDO8GgNH,iv:1VEoJMJMVw/g3WVJtO4gm+ZIsKh+IVwtaKXDhAbYssY=,tag:Ju3x6xxJshEtn5ojvdArbA==,type:str]
-  PAPERLESS_DBPASS: ENC[AES256_GCM,data:u/cUR6Y2r6R30avoj0AIW8c6pB8SCkEoSoeuCrN6tNMbvb/eMjXqGA2h2zvg5cl77aLMsksg+8f0NECTiD6VEA==,iv:A6H5qLfyzDZYN54OyU9agwhIMncGlWsYPmmNig/GBOs=,tag:SJOhpgdQpUThn4FgtlcbeQ==,type:str]
-  PAPERLESS_ADMIN_USER: ENC[AES256_GCM,data:fUXCnxI=,iv:kvmCLScDcKvhDtujnnKUDiKLOtcMXXAr2GunmDkLUCk=,tag:wjaDKqY0gnEtdfmkV+6BiQ==,type:str]
-  PAPERLESS_ADMIN_PASSWORD: ENC[AES256_GCM,data:IflBN69++q3E,iv:ULgC++jgn2ElDpIeJr1IbTx+auk9ycP/NcAQEF4j4qk=,tag:fNw4V4q6Um7lKH1KyQJdpw==,type:str]
-  #ENC[AES256_GCM,data:6yCHUs09FrD56L6y3R10V2P1L+VORFJspXeOsjM=,iv:okjpM7y/G8EK5WaqDVyKWAT4gIsAX714M9FepY7f8DY=,tag:RMHFeTOX6MGacfWfK+yQhQ==,type:comment]
-  INIT_POSTGRES_HOST: ENC[AES256_GCM,data:g3YxhZZ5BrFuiMikYu27zV3h/esF7StS04IHpcysvs3U4iBHwTxi,iv:l6aOX43s31rTqWxPaUeUnYz/Jpuj2f6yUCneB675KSw=,tag:y34I/FIUi9oEAXsQkxcFyw==,type:str]
-  INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:Gz4lzMgUJmQH,iv:Q1tuT/R9BeOEJdeX70jZ3CBmTxNRrVxYlvXg4OAxbNo=,tag:Czkck1Ld35uCqN03xP05SA==,type:str]
-  INIT_POSTGRES_USER: ENC[AES256_GCM,data:vZ94QxcsgBeX,iv:rY39c1ilbJK0vZmRd3eHwJgz1k4LaDOfgc3xAxMsatE=,tag:QHhBB2jGZianTrq3wYIZsw==,type:str]
-  INIT_POSTGRES_PASS: ENC[AES256_GCM,data:ZUvdnD9A7E7WwuShSiUyMJqEa/ybF+gCUnVaScT3sqM+d4kI8ajwJUK0dOyOcfOsVRGpzjcCB9ntcIZ/I2bwdQ==,iv:vVwMJS84KJnm68ZdW3eLLUpk4PaiHuDcvjmHzKGzdEc=,tag:du7x+frXmFRqzqQhPA2x0w==,type:str]
-  INIT_POSTGRES_SUPER_USER: ENC[AES256_GCM,data:n1GMnWgyv9k=,iv:64ay31eGMXQ1i2INMr49V5GHCqhd4x/mo0n7RJq5VfI=,tag:6SIE+E3OGVNiySAfb0aXhA==,type:str]
-  INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:lTztHR/he+BT3HUuHvE=,iv:eFu3/mLlDqkAUZdxkSOGdSm0qBrk0xZHCMMzbtr+mwg=,tag:j3f1BY/lyuwVKfq05YNR5Q==,type:str]
-  #ENC[AES256_GCM,data:xzgwEtllQuLJMialjQB8k7JmQvV92roLTHhA+k6XWfHAgkIykYzdgjbML6Ba9y7lAAXnDy6ZvoQr1841KwfOwh4W7RnF6gbU+KZgMEQffSIPFAbqOW3TI4UJpJQW/gGWaD7lpO32kgvMK9xodlpcas2jG3x2YfeOB3TASS0HrS3YToZIQkNnYTxL52UEtMS7j88W8dwKG2awenrS9oRJlGGaPQ==,iv:yBqZSp5rmmWErFRy9W4sWTEZidK8IfFZgTMxEHXFfTM=,tag:mftxPhIQZH6I6dv+PAYy3w==,type:comment]
-  #ENC[AES256_GCM,data:NQTWeisBLpa/j53+vB5XznZqBFbRf1UVVtsiA/vzIOtpFpr5Lk9yRZTdNj/HxM0snf6s5u/0kJHt06Q=,iv:aks3svg1M8F+mnxMRW66CzPUtKvHFz8f19G/cuoHtWI=,tag:GNkNuz44u5aFmaV2u/rqqw==,type:comment]
-  #ENC[AES256_GCM,data:CBiXIms9Mvprgls1FTTXI0grrUFVRtdpmq2UIQnFVX6L9S8TnP1lvOC6Re2t64RVmtcc,iv:k4eXj3OBUC3F5zyZEDBPyFdxUIO8Mh9fUsRxV4LRjQQ=,tag:mKOLRLRMPhZ9KlxtspMN5w==,type:comment]
-  #ENC[AES256_GCM,data:mbpADGHz/Bt5ZqZOYfUoNxyZJ0qryjn4V470C8RBRo788kubJQnNlsmBh18bZbz9GIq517MMSIlXiN5DM7Tq+juv5GDLTg==,iv:ElC+dVVGrbA70Bx5xg3MFELVsjuxDkyPN7fDBye7qAM=,tag:RXd+f3V5tUBkqkSLAVFb8Q==,type:comment]
-  #ENC[AES256_GCM,data:LufsdH61Alr1CWOkQqhVzCncEn/qvt61cvMYW4Fc7+sRePWUfER0wK7AMRswX0t7416C09Wf94s8IRG+XjpWsHFYD36tfIpmgrQe2Y7GoeCcodK0,iv:3yZ0YwDH4Bvo8vqTRMP25XsXYCF/y6LnX12v5eAoVBc=,tag:PDS27CZUZdH3/xEWBltNTw==,type:comment]
-  #ENC[AES256_GCM,data:G63CUwrvHDKRMFYyWcdEGu3HzH1/IxVC6CAvwGmiQ4bCxd//eOVWaCePRRw7Fwvhje2B166wkvjG,iv:Lk03ndw7EzlCRGk+ue+37RgMh/26Wjv06mASCNxDoXA=,tag:mB4Wd3NSCn2XTClgnv1bRQ==,type:comment]
-  #ENC[AES256_GCM,data:S+hzXhFKh6Bz2m3y7LmLhQIzeQ13X0jAT5EoTzcvXwXd2HdAXtAtI7uREm02ozivk96JCXg2/v+mW6anVzMn5H8=,iv:SWYZkKDNbrxHrqbX65edAF3aLvqRCMoTsZLQKaVIoNQ=,tag:O9EFfSjpC7fDIAcnFc/WKw==,type:comment]
-  #ENC[AES256_GCM,data:P5tEFfE8EALmXCJaiKrgMMNmBnyTwH5EhhyPpH4Vt0WtOy7Lf40OIK3fYkTq7OzspNXZTYnxSLBFecbNIA==,iv:O2HyODYu9h860Wevclq3uTfwUd0ttNGsLzwfetrM7Es=,tag:rSuhQEHQKj81ZbiO2J8SOw==,type:comment]
-  PAPERLESS_EMAIL_IMAP_HOST: ENC[AES256_GCM,data:+3sT8cJU/xr874MIMPg=,iv:4sKVOOppPjJdfwClngJgQMhvo8zvAbui0p7/QItZ6iY=,tag:COxlPUMulP6MVKvQShTMbw==,type:str]
-  PAPERLESS_EMAIL_IMAP_PORT: ENC[AES256_GCM,data:HFYB,iv:0Wd911gy/3mOMi5OcsHQ/Xk3fUKDltXLV/zAAFa11vY=,tag:XIyqB80QUm9pQJyalOKKbw==,type:str]
-  PAPERLESS_EMAIL_IMAP_USER: ENC[AES256_GCM,data:17bk7M9m9o72EOz898uA/+S71Yj6TTgQ,iv:/gK+bMHKTu68n+ASyfkZN+kLy0MA1+tNQWIwvW1fV8w=,tag:uqb9J6lvRzxd7jkLipR3GA==,type:str]
-  PAPERLESS_EMAIL_IMAP_PASSWORD: ENC[AES256_GCM,data:csq642qonVlXIa86cB5tJtoFZUoQQsISSNGhygaJXF64QBic0g==,iv:n2hHJO4om526elt4TV4uMzlXw4G1y0JtyoSlIj0C1eY=,tag:8FqVldYDbQyTHzFx9zRLyQ==,type:str]
+  PAPERLESS_SECRET_KEY: ENC[AES256_GCM,data:GhGZfanVBk2dEdF7htVGlmaXM2wuBYLkuYljDUQUAONoeyljfc+I0IEO+SS7KI/aEqt6y82+kHXhCNuPp0i42a8RrvnleVGDufQn5F145SI/bVdUQW9EZsuzZWaYQdrLMzv2Xm7dejOY20IWoQ7QifRH1Oa14TnFU2xniw==,iv:5a7qqtT4PyA6xHOeBldMF9TrTri61UAxjXAt3MzHzT4=,tag:7oZbvQcDPPBHx8fOpT7z4g==,type:str]
+  #ENC[AES256_GCM,data:kSi88bhUcwXcFQreURXLKGa68D/g1oj8+CTSp+g8gqmiJXTMkmnv1lsXo9G+RbfWOdzN3fsKTuHW9EISLsOJPZgMBRv1d5R2,iv:ow8Evm16xeIKdroEg9/HE3uxMzfUTL3/25N9AAoGCpY=,tag:GZMmwbx0d+jaWSZur1TOfQ==,type:comment]
+  PAPERLESS_DBHOST: ENC[AES256_GCM,data:p716w3CPy4QiehkpPR2fR2czNTjipBVH+w2qOPj03U0zzYtpW6Ku,iv:hDUy7Koe9xRUJ5VpWScIA8uXrll5tw9MlWRjzbsclJw=,tag:ArzrLd470mvJ/GDLmRjVlw==,type:str]
+  PAPERLESS_DBNAME: ENC[AES256_GCM,data:khL5+Z6fThHD,iv:MXl64jZQmiujL7mu9XwCGTBZ3lpMx61Y5QPaa46XGC4=,tag:RS62lxopNfLdfN9jEpkv7w==,type:str]
+  PAPERLESS_DBUSER: ENC[AES256_GCM,data:CBUc4RdDqv30,iv:jZBKgiCDHq765dOZB7yfowpGEWUIWVfQ3qIiS12MT34=,tag:71DrrHAuRgu/r91t+/UexA==,type:str]
+  PAPERLESS_DBPASS: ENC[AES256_GCM,data:fE+zbp64wdq1Aocg1Uo5ygDZ2A9+XnAugpgOhMX76GR/64MEC9Ufy/CBWo1E0VbAuqab87Y6wcarkE/XCEMw/A==,iv:G4pJjwNmYaq5qvA5esSXyD1ylTE9MAgN31BV1T6GgtQ=,tag:40GHbsLOEof3ZZTSE6h4+Q==,type:str]
+  PAPERLESS_ADMIN_USER: ENC[AES256_GCM,data:j2ecy0o=,iv:VFCe7BbaScmZAuMJkkaPgQ7rOQzXdjxJnwLrpr0BFOs=,tag:SyfKYxj/7alApGluuFXlMA==,type:str]
+  PAPERLESS_ADMIN_PASSWORD: ENC[AES256_GCM,data:88X/PbcWN5w2,iv:43lGuCekG7Yzusw1oyZ1HQYcReAaI9rfFWwfMTVLxx4=,tag:kdiEdUosuqM0EgAxAHbrEg==,type:str]
+  #ENC[AES256_GCM,data:3mAHRtlkLTdwYgf2Nc2iI7Dsdogr0j6c3S4fy14=,iv:tCQM05CFAeTkcow5slcp3CjQ25UhHLWsrA6eLgiCkV8=,tag:NkhGU/mp/3qlI+Xb4KbN+g==,type:comment]
+  INIT_POSTGRES_HOST: ENC[AES256_GCM,data:MOYL1BeSm+B1IlSMnjv2pm+eYeMQC+NMNYJtlIJXdvM8hjXzAVil,iv:JHoq0FavItc0LeNkCDhjzsiJtO6PnHauQ5uQwlEioCk=,tag:pXvsWDJs/RE7+ROq004kEg==,type:str]
+  INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:bjVS6na7gFUU,iv:SIhQBwqpAJxMiPeogIVZkqxDQhQaaZA0iwKSCUxdzYU=,tag:yTy2iRSFNBqfZzpiv7lyCg==,type:str]
+  INIT_POSTGRES_USER: ENC[AES256_GCM,data:1126RHd52Gw0,iv:TyFLqR7X+HPxfFkG/GWOlnMgWBVBTEWzXPa3kSyFMQw=,tag:Wih5IgcxHAogpf5k/QvMPg==,type:str]
+  INIT_POSTGRES_PASS: ENC[AES256_GCM,data:PRHbwR9Ke1IigUQ46acB7pMgbvuqijo6pE0BD3L/NnjK6PDxnF7Hr7KXy8igGGRDKfvnFf2ojIvy8HuV9QtoiA==,iv:A2DMaL36USwU0OzLM/uu6KKVt0z3sGlZaApOBLLoZk4=,tag:6p97z89EfH+Btb/+mwSWLQ==,type:str]
+  INIT_POSTGRES_SUPER_USER: ENC[AES256_GCM,data:YE0R6tguE1E=,iv:BVc7Jry7SmdjVUGawkLOUJHh2SJ550Zy1IyKmFJWiZQ=,tag:gDAkNOj4aBh4LNlGwJnfYg==,type:str]
+  INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:doHWyyXLfVS5GWQ8fdk=,iv:VM4xLPGRI1mub2rAWKR30y7Cq8foHhOlgcx/PgIObMw=,tag:1kRkZYa19CNRwhZwrRo+sQ==,type:str]
+  #ENC[AES256_GCM,data:43FIjdb5887UACgzHrPQMhedqNsaDhmjNRTtZ2ga2Kusk3YT2y3j3+L+10LQolQnUaSl7QRey6aagMKaEnvbWlw66FSnTNRYHbKPLQs3WGOmYyZBDA4Aqnw4JNDVF2rSBRpiLZBmBkZ/uTPw/NEAHOOYxUCI0YuKdB8ptBhqMe3pQr4kNUOhgPB9o/5q3Nl2V3/ia9lXwtVA2UVtYr6apo9ddA==,iv:bOqBGaAX7Qd5U4WoeggtgaPNYNS3g5plLHMrlUgjOaE=,tag:uFUfF9+f3/FU7HONY5g+EQ==,type:comment]
+  #ENC[AES256_GCM,data:5oAAvW2noN95dOAFujfRTaKwXaUESeGkLYsHCF9kc3hIcz/F/ORGec+rpE6MbxMbbp9hjmM0HC5/CdA=,iv:x32F/hlZGH1JYAHJ0eTf5Z0iZIG0hDW9B1OBiynkqhQ=,tag:hiyd5Wmp9+ucB1ySFPEVAQ==,type:comment]
+  #ENC[AES256_GCM,data:HaZOAUjsVCfgu/3jlfwbu6LshNfEuKIEnn0/X0ZN/1gMmgBeTAYfZkpB+aBEY+iB3UGa,iv:5HdPnnBXtQAXLWdMSm1CKo9VdAF+oC15RFRAl2bJJPA=,tag:20JIHl59etVfkxmnaEUKkQ==,type:comment]
+  #ENC[AES256_GCM,data:R4bcaIg8ol85+Sb5vHQ3+X0r7884o7PDyACq9bceIuqCwJLBfj23QaW4+CHMYNT9gv58i/pCor9KZvOedpAZ0fV4nHH/Ow==,iv:/dOR1WgiX7AyBNI9OnQyw/ucVzCRqdqBkGcY4MZ+l1s=,tag:/JmFftoCeLOVWQLOH8aePw==,type:comment]
+  #ENC[AES256_GCM,data:YwxNPd+oFRJ0HbtFBwlb4mlGZvtRjXr3gYPRimTT4AZ/lmWd9nOMV0ttqDrUscsZsIIFSSX/4sydTagxNy8p3KqmYyieFQkAtE/f388eDFW2uA/8,iv:ROCAv3UXDU6CNTSTcWZOpovOBkvNximQFtmDagbNXoE=,tag:pUHMlTSv60fow+NsuUZcsg==,type:comment]
+  #ENC[AES256_GCM,data:5S6xnzA9cWdaQqeBF4ZlrtlRZOEJkdny7BCWiGb/ItZpGB8Rzv2DBQLfRNNykPTWn0xSkuj/xs9+,iv:zO0d0ZAdQU4O2Qy5ptzxh5YddJNsflLtpmzJsxpnbo0=,tag:9mAuBo7v3fJA2LA0ZAJveg==,type:comment]
+  #ENC[AES256_GCM,data:DyQyxD6HKSLOzBxL/+FeOKuK3r5VtfDjLAePwaBKZ3wyRcjhrrR2QpqEe4oYCh/YDkL81vn1mY6HzuKx4gPoa7E=,iv:jVmjlRh6S7H4vEPw0PWGQN8uvvv9IzFaTV85m+4aI4M=,tag:8o7EQy6AycAXKG+81bXZNg==,type:comment]
+  #ENC[AES256_GCM,data:G1yJdYY3uuW7CC7QEP4vzf42WCUKuY2eJLmRPL3kHXDjxIhK08hEiNL9bmkQc0gkkIDGojxaQ2oNAsIs6g==,iv:a+vK1+2C07A4mc6IhuBI7pyohKgeI4ZsPgJ5qSwM5e8=,tag:RAZtl+gQ7zJKbHwfJsXz2Q==,type:comment]
+  PAPERLESS_EMAIL_IMAP_HOST: ENC[AES256_GCM,data:73NFf0/Z7mIpynoVcv4=,iv:0rSYJxHh862QfJFG4o1gsrzqkYbXk5TrMf1MSdj885I=,tag:Lx3BD71hnwTVtE031B+C4A==,type:str]
+  PAPERLESS_EMAIL_IMAP_PORT: ENC[AES256_GCM,data:qHWI,iv:0Tw5tm6hHxOd8ofHZ5nE28e1hwHpvG4P3SiiacdwN1A=,tag:4UMgmYTcP30H+/yaH2ywrw==,type:str]
+  PAPERLESS_EMAIL_IMAP_USER: ENC[AES256_GCM,data:/n7FSO3c+d0C8h7s2i/Hh4s=,iv:W/LdSvqKZvSTaUEa0LPHL9Fa697uXWR1GCGPZNIKr58=,tag:npLx5vESAtwkqtgplZukew==,type:str]
+  PAPERLESS_EMAIL_IMAP_PASSWORD: ENC[AES256_GCM,data:cJqaMrG6mV90KlEfM3DXjX4EoQ==,iv:OcPFBn0q6EpM7C4RXOiPenBeGDCnnDza8IfxbeBPmqc=,tag:G7b34IMHBrxaJX6nmdacEg==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzNS84SUViaGtOalN0cU52
-        ZzRtQ0UwcGlEUUZFUlVQSUdXVXBnbWJGRFVJCjlvTDRFZEdGYUFTMDJ2cFp2RzBu
-        NlRQY2JESWRpLzBuOGwxd1YvZGRkM2cKLS0tIGJjY2VUbmZGS1N4VnNsVUM0ZnFz
-        MXlLYkkrd3ZSS015eDVoYlhDZW9vVEEKIlj0giJD0aVxKY09sZzStBAfjuqQ3MyK
-        Go2lVuhc4e0KmP20eUE3hB0TEeEXcXDPGmmI+V/F3CdPN5X+DLLtlw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwZThuUDZkbVQ2Yk55dTM3
+        dDZzMXIwTTQ4NVdaM1paK240cDJYc001dlYwCkg0eENtREZLcjZFSXFhbkdGVVY1
+        ZDBudzBHeEVkckR0SzU2NlRNS2JJQk0KLS0tIDMrekFIRzVIUkg2SkVPMDZwdmxQ
+        UmFkZ1F0UmRqa1Q0SDFoT052d2FyQ1UK2Am619eUDG0sGr8EzQqME+0SyQptGX9O
+        fxSkUzRx8Orms5ju7e8sq9GiVx7SA4hjwfVhZh8o05MS02dDq126pQ==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1qwwzsz6z2mmu6hpmjt2he7nepmnhutmhehvkva7l5zy5xzf08d5s5n4d6n
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-05-27T23:22:34Z"
-  mac: ENC[AES256_GCM,data:GTef1FmKZPxW21dJm48J2pQqsqJa+yPtzi9CwtoGDUbLsG6aTBXbcZj4E8O/FsBZw4+rIb/gbkohLLp6trPeGbY7taZ7SkHNNlIsR3O1Xb6nO2qFXgjpqTPZCDOU20ZjUaEiMy2zYrzX9R6pUTt6DWwuw2TIJIe7fsPgqabj+G4=,iv:Uy1oyCylXDvffMaB7ya7wOISCGZkWjFMu9uV1puOKzs=,tag:QYTsM6dAP/396ikpGdtWow==,type:str]
+  lastmodified: "2026-05-27T23:27:17Z"
+  mac: ENC[AES256_GCM,data:V0Jaj1EAlyjWVVTWqQLyGq4P7sj1Y2FhJi1ZAI0BMRZYSyGZNKycucCvAGr3votTyP4WgZv7HBsmjoSwxbVLOLvJPQyHEPnH5Dg7sns25rsaGKDuGObtcqcjPkZuoGhrluRDcPf8FYiL3ApApygtK/nCxyR32nHmsUh2hgGU72A=,iv:kEg8vUGRR/tj5TsB2r0HWjOIhEEFVuk/SvQH3JnsO/I=,tag:871cw5pvxQyqz96maRpbtA==,type:str]
   mac_only_encrypted: true
   version: 3.13.1

--- a/kubernetes/apps/services/paperless/app/secret.sops.yaml
+++ b/kubernetes/apps/services/paperless/app/secret.sops.yaml
@@ -1,40 +1,48 @@
-# IMPORTANT: This file contains plaintext secrets.
-# Before committing, encrypt with: task sops:encrypt-file file=kubernetes/apps/services/paperless/app/secret.sops.yaml
 apiVersion: v1
 kind: Secret
 metadata:
   name: paperless-secrets
 stringData:
-  #ENC[AES256_GCM,data:DVc35/PT9biV+Uj4EWTxeZWvVZ2gvr3w9iC/hF1O60TVt4Cc8AUZ2fpI7PivaQFzWYEhbPTMnwo0CFw=,iv:6RwnykjbQ5rVzdYixERdiSewqbXjqrxk3Say68B5vzY=,tag:IkAGji2WHSRPw0GHIs3dFg==,type:comment]
-  PAPERLESS_SECRET_KEY: ENC[AES256_GCM,data:lMCDflwRFZHABE6RW2QHkt78lY/ESjqBd3L1OWL9Y+VME70uiv33HNAfOcQLnTkmCZOm5+GTvtm0WjOim4CgOUBXmxVZWGoyVhNlr4mgTGA/NTFdEIr6k7jr0cS6vzGb/AFlyN6SVt18wQ4llB6wio5HMboCjiGGz17Gbg==,iv:cXTIk2fan7ef3Mm0P3GdieCURGRiL+LUs3R1kmQqGsw=,tag:CFiwuObMxfuUgfPboH8A0A==,type:str]
-  #ENC[AES256_GCM,data:ohEo7W+0RwOZwjxODWDoHOUi5XYkcPJerLjgEjuzH7NQovS9gfccwGj3ZW3veya13YcKFt+T1kuE0hSQrJZQ56G9OpO9TRngdZVfF3s=,iv:qxK7lVJL4Z1WB6qhc5+2Skst6Xi4Q2BpO37Fk0lB9AY=,tag:P1jJm0xcriyhq0/RenS/AA==,type:comment]
-  PAPERLESS_DBHOST: ENC[AES256_GCM,data:QGJ7dQIhYXLfFf9y8HApJpP54SLSR3t1djDdkAns/5QXbmJS+VbNkmc=,iv:FohyvJfe3VMde193hiSFUx4SkPreaImFFtzr2oMlz0I=,tag:JTzL50hdL3Z64MDw1Ku96Q==,type:str]
-  PAPERLESS_DBNAME: ENC[AES256_GCM,data:YQdXBs40vBOt,iv:9rt5Z66kYkixyn8LE8sJGEZiviqeUo8Hld15Hcz9nSo=,tag:DQX+ezf10hZ5v4YuIBzlVQ==,type:str]
-  PAPERLESS_DBUSER: ENC[AES256_GCM,data:DrOZKU0WptKP,iv:CRT3x9twOq6s3MbJDNMcDH+QG44Cz3QuYeHEFYUrO4U=,tag:AetC8RdkmGm+w2LAltUDGQ==,type:str]
-  PAPERLESS_DBPASS: ENC[AES256_GCM,data:AK0KiDhijjRbb8ZEBAiZfY2cIgMJPUx5U+bRL+CId7RbQITCNP7uYCMYrtR7n+91W8mWIr6bWIdJXtooNiy5Gg==,iv:qd7s7STd8F7A6BePx3zcuoiaKr7HbFWt/Gaqqe5noDY=,tag:cok48eBK0b2eJHJK3WnCww==,type:str]
-  #ENC[AES256_GCM,data:LIDBKULUfBzstuVpaaCWZUSRih8S/QPL2JpAm8ZAtuDe4kvobABzxUS/GZ9w75kL,iv:fiIq6ukuu1YtQvnMGd5TuDbTqatiUYwR1QOQCEvX1BA=,tag:0fjEkaqdWYwWxRnFb9b+xg==,type:comment]
-  PAPERLESS_ADMIN_USER: ENC[AES256_GCM,data:SBpwSlQ=,iv:MXEEUJYUOmvCFXb87hnkmmT4m54mYUlBcXsTknENLmI=,tag:XSsih2fVXGdperCRVW3HgA==,type:str]
-  PAPERLESS_ADMIN_PASSWORD: ENC[AES256_GCM,data:DxgRR40nJzjs,iv:MjcHVJftrMrHW7JT2R724NU4WofgZvDD7lb4qSZXRyQ=,tag:2O16qOUi7GtKOQr6G+YfAQ==,type:str]
-  #ENC[AES256_GCM,data:gZTH8GUylyxw3tAK1HDFUyoO/AcOiYOFsZ5pk5Zxji9xhT0U4RSOYsP6dXG80bBH7mPBmJdr7022SSVhdanAqGldBPZ4wd0=,iv:6ReaP5d5lHK44Z89kOOcsGlcR81ugiaN9jz0PmRJ39M=,tag:JydXVf2USFsBMvtgmSp55Q==,type:comment]
-  INIT_POSTGRES_HOST: ENC[AES256_GCM,data:Hlae+cJL0/l2rCo+RzvvlWA2D6cev0PRe06pLlqeVH3K7BBmxIB6rzE=,iv:5772iTKO/BQhWWoMRT/dJcyKVmpvMyOe834S2Z+E9V0=,tag:c1cotVxUSemoGRI0RuSisw==,type:str]
-  INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:Echv08kC5iOB,iv:ykaHnG1SsPSDw9zp57ggjNEwU3rdSbmUTOM2ynMt9+U=,tag:BetjbtUjVws+7r2NJvWxeA==,type:str]
-  INIT_POSTGRES_USER: ENC[AES256_GCM,data:BIYw3fZrik7E,iv:4J5VJ5A2Blj96ipSWVMaNQorHJnypOjWPME/TJidoPc=,tag:ldhWYi5DwxrjRGMSTYs7eA==,type:str]
-  INIT_POSTGRES_PASS: ENC[AES256_GCM,data:BBcDPpY1T3xxj926O1pFnhA1xlo5FviC0RY6awAVHf9rMGYnog9kpBiplplbFgGorVaSdWaq/4SCCYsXPv6h5w==,iv:4NwLgKLjFDII24N0e0zNmyP50aOYSbkNOBKx6y07LIw=,tag:I1oof0FCiFB6fgGMVfg3JA==,type:str]
-  INIT_POSTGRES_SUPER_USER: ENC[AES256_GCM,data:XnsMVt4rIKU=,iv:V9YU9TMRs/Nb7j04GlfPnGlGcRvarhk6/5SIAm+tkoA=,tag:nO9yRdCUCdutY6AGx0z6+g==,type:str]
-  INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:oCOEJJPjjnLz5boHhY0=,iv:+ORnzfN3pgRa+khbPwLQDQe+LHg5yI1P6yL6mUU0r4U=,tag:l/OZskvI8ryyJo/u74Nomg==,type:str]
+  PAPERLESS_SECRET_KEY: ENC[AES256_GCM,data:zrGNummFKbbzYVg/5gE7IHDjEJAcSWdD9QPV4ojXXO/KMUObOiJo/uejyZPglVcFuVLXScYLOPSKKubtcbr7Yl5DwPBlzggyYNmzLKGJK+Uz+rrrOma7TRnOQSu+eie8CeVlzqzKc4mhWwmvnEk1KcAqZN87HpU4W7+jEg==,iv:fEg9K9Yg+x+YaI29rpvgFY3K3b+7PEryGdJICV86LZY=,tag:BHLIFi8157XWptSLZzCH9g==,type:str]
+  #ENC[AES256_GCM,data:rQG2LUqKCw2lGUe6sQD3yHaW+xTj6E5wIJj0CDUpedD1UefdR9SF19DtlVrPLBz7nX0W2qbpVXBxcNHbhuy7VxZhwe4FpvA+,iv:eeQ30HxZEGKlQyO7B9cJnCqwz/S4/8IVvkD0fuFG9Fc=,tag:H8rj9PujciOdlx3gUVyxAA==,type:comment]
+  PAPERLESS_DBHOST: ENC[AES256_GCM,data:e0EDqAKb2bqDlNK5Vi8P2/ub25dFHy/COtp8UD4dOC2n/T2d96T+,iv:OEfIdL78gLuiP0A75NfvtdYPtgEgulrPKoDFnlBNI20=,tag:nsDbgqjcPPHWlxmC6Y2yGQ==,type:str]
+  PAPERLESS_DBNAME: ENC[AES256_GCM,data:eGuJyu95Zrkn,iv:/hZdaXh2WfS1WdDVbxjtVr1LOYbln99ub/RcoRFkpz8=,tag:av7ylm+0dnM2e2HOd43PEQ==,type:str]
+  PAPERLESS_DBUSER: ENC[AES256_GCM,data:97s6WDO8GgNH,iv:1VEoJMJMVw/g3WVJtO4gm+ZIsKh+IVwtaKXDhAbYssY=,tag:Ju3x6xxJshEtn5ojvdArbA==,type:str]
+  PAPERLESS_DBPASS: ENC[AES256_GCM,data:u/cUR6Y2r6R30avoj0AIW8c6pB8SCkEoSoeuCrN6tNMbvb/eMjXqGA2h2zvg5cl77aLMsksg+8f0NECTiD6VEA==,iv:A6H5qLfyzDZYN54OyU9agwhIMncGlWsYPmmNig/GBOs=,tag:SJOhpgdQpUThn4FgtlcbeQ==,type:str]
+  PAPERLESS_ADMIN_USER: ENC[AES256_GCM,data:fUXCnxI=,iv:kvmCLScDcKvhDtujnnKUDiKLOtcMXXAr2GunmDkLUCk=,tag:wjaDKqY0gnEtdfmkV+6BiQ==,type:str]
+  PAPERLESS_ADMIN_PASSWORD: ENC[AES256_GCM,data:IflBN69++q3E,iv:ULgC++jgn2ElDpIeJr1IbTx+auk9ycP/NcAQEF4j4qk=,tag:fNw4V4q6Um7lKH1KyQJdpw==,type:str]
+  #ENC[AES256_GCM,data:6yCHUs09FrD56L6y3R10V2P1L+VORFJspXeOsjM=,iv:okjpM7y/G8EK5WaqDVyKWAT4gIsAX714M9FepY7f8DY=,tag:RMHFeTOX6MGacfWfK+yQhQ==,type:comment]
+  INIT_POSTGRES_HOST: ENC[AES256_GCM,data:g3YxhZZ5BrFuiMikYu27zV3h/esF7StS04IHpcysvs3U4iBHwTxi,iv:l6aOX43s31rTqWxPaUeUnYz/Jpuj2f6yUCneB675KSw=,tag:y34I/FIUi9oEAXsQkxcFyw==,type:str]
+  INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:Gz4lzMgUJmQH,iv:Q1tuT/R9BeOEJdeX70jZ3CBmTxNRrVxYlvXg4OAxbNo=,tag:Czkck1Ld35uCqN03xP05SA==,type:str]
+  INIT_POSTGRES_USER: ENC[AES256_GCM,data:vZ94QxcsgBeX,iv:rY39c1ilbJK0vZmRd3eHwJgz1k4LaDOfgc3xAxMsatE=,tag:QHhBB2jGZianTrq3wYIZsw==,type:str]
+  INIT_POSTGRES_PASS: ENC[AES256_GCM,data:ZUvdnD9A7E7WwuShSiUyMJqEa/ybF+gCUnVaScT3sqM+d4kI8ajwJUK0dOyOcfOsVRGpzjcCB9ntcIZ/I2bwdQ==,iv:vVwMJS84KJnm68ZdW3eLLUpk4PaiHuDcvjmHzKGzdEc=,tag:du7x+frXmFRqzqQhPA2x0w==,type:str]
+  INIT_POSTGRES_SUPER_USER: ENC[AES256_GCM,data:n1GMnWgyv9k=,iv:64ay31eGMXQ1i2INMr49V5GHCqhd4x/mo0n7RJq5VfI=,tag:6SIE+E3OGVNiySAfb0aXhA==,type:str]
+  INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:lTztHR/he+BT3HUuHvE=,iv:eFu3/mLlDqkAUZdxkSOGdSm0qBrk0xZHCMMzbtr+mwg=,tag:j3f1BY/lyuwVKfq05YNR5Q==,type:str]
+  #ENC[AES256_GCM,data:xzgwEtllQuLJMialjQB8k7JmQvV92roLTHhA+k6XWfHAgkIykYzdgjbML6Ba9y7lAAXnDy6ZvoQr1841KwfOwh4W7RnF6gbU+KZgMEQffSIPFAbqOW3TI4UJpJQW/gGWaD7lpO32kgvMK9xodlpcas2jG3x2YfeOB3TASS0HrS3YToZIQkNnYTxL52UEtMS7j88W8dwKG2awenrS9oRJlGGaPQ==,iv:yBqZSp5rmmWErFRy9W4sWTEZidK8IfFZgTMxEHXFfTM=,tag:mftxPhIQZH6I6dv+PAYy3w==,type:comment]
+  #ENC[AES256_GCM,data:NQTWeisBLpa/j53+vB5XznZqBFbRf1UVVtsiA/vzIOtpFpr5Lk9yRZTdNj/HxM0snf6s5u/0kJHt06Q=,iv:aks3svg1M8F+mnxMRW66CzPUtKvHFz8f19G/cuoHtWI=,tag:GNkNuz44u5aFmaV2u/rqqw==,type:comment]
+  #ENC[AES256_GCM,data:CBiXIms9Mvprgls1FTTXI0grrUFVRtdpmq2UIQnFVX6L9S8TnP1lvOC6Re2t64RVmtcc,iv:k4eXj3OBUC3F5zyZEDBPyFdxUIO8Mh9fUsRxV4LRjQQ=,tag:mKOLRLRMPhZ9KlxtspMN5w==,type:comment]
+  #ENC[AES256_GCM,data:mbpADGHz/Bt5ZqZOYfUoNxyZJ0qryjn4V470C8RBRo788kubJQnNlsmBh18bZbz9GIq517MMSIlXiN5DM7Tq+juv5GDLTg==,iv:ElC+dVVGrbA70Bx5xg3MFELVsjuxDkyPN7fDBye7qAM=,tag:RXd+f3V5tUBkqkSLAVFb8Q==,type:comment]
+  #ENC[AES256_GCM,data:LufsdH61Alr1CWOkQqhVzCncEn/qvt61cvMYW4Fc7+sRePWUfER0wK7AMRswX0t7416C09Wf94s8IRG+XjpWsHFYD36tfIpmgrQe2Y7GoeCcodK0,iv:3yZ0YwDH4Bvo8vqTRMP25XsXYCF/y6LnX12v5eAoVBc=,tag:PDS27CZUZdH3/xEWBltNTw==,type:comment]
+  #ENC[AES256_GCM,data:G63CUwrvHDKRMFYyWcdEGu3HzH1/IxVC6CAvwGmiQ4bCxd//eOVWaCePRRw7Fwvhje2B166wkvjG,iv:Lk03ndw7EzlCRGk+ue+37RgMh/26Wjv06mASCNxDoXA=,tag:mB4Wd3NSCn2XTClgnv1bRQ==,type:comment]
+  #ENC[AES256_GCM,data:S+hzXhFKh6Bz2m3y7LmLhQIzeQ13X0jAT5EoTzcvXwXd2HdAXtAtI7uREm02ozivk96JCXg2/v+mW6anVzMn5H8=,iv:SWYZkKDNbrxHrqbX65edAF3aLvqRCMoTsZLQKaVIoNQ=,tag:O9EFfSjpC7fDIAcnFc/WKw==,type:comment]
+  #ENC[AES256_GCM,data:P5tEFfE8EALmXCJaiKrgMMNmBnyTwH5EhhyPpH4Vt0WtOy7Lf40OIK3fYkTq7OzspNXZTYnxSLBFecbNIA==,iv:O2HyODYu9h860Wevclq3uTfwUd0ttNGsLzwfetrM7Es=,tag:rSuhQEHQKj81ZbiO2J8SOw==,type:comment]
+  PAPERLESS_EMAIL_IMAP_HOST: ENC[AES256_GCM,data:+3sT8cJU/xr874MIMPg=,iv:4sKVOOppPjJdfwClngJgQMhvo8zvAbui0p7/QItZ6iY=,tag:COxlPUMulP6MVKvQShTMbw==,type:str]
+  PAPERLESS_EMAIL_IMAP_PORT: ENC[AES256_GCM,data:HFYB,iv:0Wd911gy/3mOMi5OcsHQ/Xk3fUKDltXLV/zAAFa11vY=,tag:XIyqB80QUm9pQJyalOKKbw==,type:str]
+  PAPERLESS_EMAIL_IMAP_USER: ENC[AES256_GCM,data:17bk7M9m9o72EOz898uA/+S71Yj6TTgQ,iv:/gK+bMHKTu68n+ASyfkZN+kLy0MA1+tNQWIwvW1fV8w=,tag:uqb9J6lvRzxd7jkLipR3GA==,type:str]
+  PAPERLESS_EMAIL_IMAP_PASSWORD: ENC[AES256_GCM,data:csq642qonVlXIa86cB5tJtoFZUoQQsISSNGhygaJXF64QBic0g==,iv:n2hHJO4om526elt4TV4uMzlXw4G1y0JtyoSlIj0C1eY=,tag:8FqVldYDbQyTHzFx9zRLyQ==,type:str]
 sops:
   age:
-    - recipient: age1qwwzsz6z2mmu6hpmjt2he7nepmnhutmhehvkva7l5zy5xzf08d5s5n4d6n
-      enc: |
+    - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3MDV4QXI2Wm9FeU9uRHcy
-        T25lQ3hXRFFjMUNYb3AvK3ZJeVdlNDE2LzJFCjNTd3lNSU1jY1lyTGQrSWlFTVI2
-        S1ROczlEYUhNb2dwN29mbFdhZXlWM2MKLS0tIHFWUDNiVTkwUktOWVNXSUhzTVly
-        QWJEM0dwMitydHkvQTBMNm43SFBwMmMKd29lHsmxtp66WCEgUA8Ny0jpLsVzwyl7
-        tfclZpX5kBhU4axnLfYusp1bAbAAbi356qj30YV6244uipWHk2I6rA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzNS84SUViaGtOalN0cU52
+        ZzRtQ0UwcGlEUUZFUlVQSUdXVXBnbWJGRFVJCjlvTDRFZEdGYUFTMDJ2cFp2RzBu
+        NlRQY2JESWRpLzBuOGwxd1YvZGRkM2cKLS0tIGJjY2VUbmZGS1N4VnNsVUM0ZnFz
+        MXlLYkkrd3ZSS015eDVoYlhDZW9vVEEKIlj0giJD0aVxKY09sZzStBAfjuqQ3MyK
+        Go2lVuhc4e0KmP20eUE3hB0TEeEXcXDPGmmI+V/F3CdPN5X+DLLtlw==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-04-30T20:45:38Z"
-  mac: ENC[AES256_GCM,data:J513djku//cKJbV4Hb7n0bO0dSH0N74TJTXtlF7e3CR5gtpxhbyvi0ctmAprTFIS7RTv1kruuxGtU1zNzPDdPkaMrg/fEBbIra2Muvyv86vnYZewautqWEVyIRvORHBsnYQ4p829YGoE/ktBVtpo6WQxdRDRFEk0DTgcGR6y2dQ=,iv:UkQRCTZzJF6FPYGDliOPuWz6Klu6DHWQqOdVNBlFHnA=,tag:hFyrskVxb1CGq2PzbR094Q==,type:str]
+      recipient: age1qwwzsz6z2mmu6hpmjt2he7nepmnhutmhehvkva7l5zy5xzf08d5s5n4d6n
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-05-27T23:22:34Z"
+  mac: ENC[AES256_GCM,data:GTef1FmKZPxW21dJm48J2pQqsqJa+yPtzi9CwtoGDUbLsG6aTBXbcZj4E8O/FsBZw4+rIb/gbkohLLp6trPeGbY7taZ7SkHNNlIsR3O1Xb6nO2qFXgjpqTPZCDOU20ZjUaEiMy2zYrzX9R6pUTt6DWwuw2TIJIe7fsPgqabj+G4=,iv:Uy1oyCylXDvffMaB7ya7wOISCGZkWjFMu9uV1puOKzs=,tag:QYTsM6dAP/396ikpGdtWow==,type:str]
   mac_only_encrypted: true
-  version: 3.12.2
+  version: 3.13.1


### PR DESCRIPTION
Paperless-ngx:
- Re-enable (was commented out). postgres-init image bumped to :18 to match current CNPG PG18 cluster.
- postgres hostname: postgres17-rw -> postgres-rw (version-stable alias).
- Redis URL: added /2 DB selector (DB 2 allocated for Paperless per dragonflydb-db-allocation.md; previously had no /N so defaulted to db 0).
- Route: added authentik-forwardauth ExtensionRef filter (was missing — would have caused silent 404 same as AnythingLLM).
- Gmail IMAP: PAPERLESS_EMAIL_TASK_CRON every 10min; IMAP credentials in secret (PAPERLESS_EMAIL_IMAP_HOST/PORT/USER/PASSWORD). User and app password are placeholders — fill via sops-edit-then-encrypt after generating Gmail App Password at myaccount.google.com/apppasswords.
- DragonflyDB DB registry updated: DB 2 = Paperless.

n8n workflows:
- home-ops-webhook-sync.json: GitHub push webhook → AnythingLLM. Triggers on push to main branch. Ingests/deletes changed .md and .yaml files into workspace 'home-ops'. Webhook URL: https://n8n.68cc.io/webhook/home-ops-github-push
- home-ops-full-resync.json: manual trigger. Walks full repo tree, ingests all docs/**/*.md + CLAUDE.md + kustomization/helmrelease yamls into workspace 'home-ops'. Run once to seed the workspace.

Both workflows need credentials created in n8n UI before import:
  - 'GitHub Token': HTTP Header Auth, Authorization: Bearer ghp_...
  - 'AnythingLLM API Key': already exists if Linkwarden workflow is set up