### PR TITLE
feat(monitoring): expose vmsingle write path for off-cluster agents

### DIFF
--- a/kubernetes/apps/monitoring/victoria-metrics/app/httproute.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/httproute.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# External remote_write ingest for off-cluster agents (e.g. the operator's
+# MacBook running vmagent). LAN-only via traefik-internal-gateway — no
+# Cloudflare record is created, so this is unreachable from the public internet.
+#
+# Path is intentionally scoped to /api/v1/write ONLY. vmsingle's full API
+# includes destructive endpoints (e.g. /api/v1/admin/tsdb/delete_series); since
+# this route carries NO authentication and trusts the LAN perimeter, exposing
+# only the write path keeps the blast radius to "inject junk metrics"
+# (recoverable) rather than "wipe the TSDB".
+#
+# NO OIDC/forwardAuth middleware here: remote_write is machine-to-machine and
+# the Authentik forwardAuth flow 302-redirects to an interactive login page,
+# which breaks programmatic push.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmsingle-write
+  annotations:
+    external-dns.alpha.kubernetes.io/target: 192.168.35.17
+spec:
+  hostnames:
+    - vm-push.68cc.io
+  parentRefs:
+    - name: traefik-internal-gateway
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: vmsingle-vmsingle
+          port: 8429
+      matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/write

--- a/kubernetes/apps/monitoring/victoria-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./vmagent.yaml
   - ./vmalert.yaml
   - ./grafanadatasource.yaml
+  - ./httproute.yaml


### PR DESCRIPTION
Add LAN-only HTTPRoute (vm-push.68cc.io -> traefik-internal-gateway, VIP 192.168.35.17) scoped to /api/v1/write only, so off-cluster vmagent instances (operator MacBook) can remote_write into vmsingle.

- No OIDC/forwardAuth: remote_write is machine-to-machine; the Authentik forwardAuth 302 login redirect breaks programmatic push.
- Path scoped to /api/v1/write to keep the no-auth blast radius to junk metrics rather than exposing destructive admin endpoints (delete_series).
- Internal gateway only -> no Cloudflare record -> not publicly reachable.