### PR TITLE
fix(traefik): harden edge IP keying, zero-downtime rollout, drop Dolt listener

### DIFF
--- a/kubernetes/apps/network/traefik-external/app/helmrelease.yaml
+++ b/kubernetes/apps/network/traefik-external/app/helmrelease.yaml
@@ -54,8 +54,13 @@ spec:
         expose:
           default: true
         protocol: TCP
+        # HTTP/3 disabled: public path is Cloudflare tunnel -> cloudflared
+        # (h2 to origin). Cloudflare terminates h3 at its edge; the origin
+        # never sees h3 over the tunnel. Enabling it would open UDP/443 on
+        # the public VIP for zero benefit. (Internal Traefik keeps h3 — LAN
+        # clients hit its VIP directly.)
         http3:
-          enabled: true
+          enabled: false
         transport:
           respondingTimeouts:
             readTimeout: 60
@@ -69,11 +74,6 @@ spec:
       # syslog (TCP + UDP) moved to traefik-internal — log ingest is LAN-only
       # and must not be WAN-reachable (L4 routes bypass the CrowdSec/rate-limit
       # HTTP middleware chain). See victoria-logs syslog routes.
-      mysql:
-        port: 3306
-        expose:
-          default: true
-        protocol: TCP
     gateway:
       enabled: true
       name: traefik-external-gateway
@@ -91,11 +91,6 @@ spec:
           certificateRefs:
             - name: 68cc-io-tls
               kind: Secret
-        mysql:
-          port: 3306
-          namespacePolicy:
-            from: All
-          protocol: TCP
     ingressClass:
       enabled: true
       isDefaultClass: false
@@ -112,7 +107,7 @@ spec:
       # Chain:
       #   1. crowdsec-bouncer — malicious IPs 403'd before any CPU spend
       #   2. rate-limit — Traefik native per-instance rate limit
-      #                   (60 req/s * 3 replicas = ~180 req/s cluster)
+      #                   (100 req/s avg * 3 replicas = ~300 req/s cluster)
       #   3. security-headers — STS/XFO/CSP on every response
       #   4. bot-wrangler — block AI crawlers per robots.txt template
       #   5. compression — gzip response body last so headers stay plain
@@ -141,6 +136,15 @@ spec:
     deployment:
       kind: DaemonSet
       revisionHistoryLimit: 3
+      # DaemonSet surge (k8s 1.22+): spin up the new pod before killing the old
+      # one so every node keeps a Traefik pod during chart/image bumps. With
+      # externalTrafficPolicy: Local, maxUnavailable>0 would blackhole the LB
+      # node mid-rollout. maxSurge:1/maxUnavailable:0 = zero-downtime rollout.
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 0
+          maxSurge: 1
       # Set GOMEMLIMIT to 90% of the container memory limit (2Gi → ~1.8Gi)
       # This ensures Go's GC runs before the OOM killer fires
       goMemLimitPercentage: 90

--- a/kubernetes/apps/network/traefik-external/app/middleware/crowdsec-bouncer.yaml
+++ b/kubernetes/apps/network/traefik-external/app/middleware/crowdsec-bouncer.yaml
@@ -28,6 +28,11 @@ spec:
       crowdsecAppsecFailureBlock: true
       crowdsecAppsecUnreachableBlock: false
       logLevel: INFO
+      # Public path is Cloudflare tunnel; the real client IP is in
+      # CF-Connecting-IP, not X-Forwarded-For (cloudflared speaks plain HTTP,
+      # pod CIDR untrusted). Tell the bouncer to read client IP from that
+      # header so CrowdSec decisions target the actual abuser.
+      forwardedHeadersCustomName: CF-Connecting-IP
       forwardedHeadersTrustedIPs:
         - 10.42.0.0/16
         - 192.168.35.0/24

--- a/kubernetes/apps/network/traefik-external/app/middleware/ratelimiter.yaml
+++ b/kubernetes/apps/network/traefik-external/app/middleware/ratelimiter.yaml
@@ -17,5 +17,10 @@ spec:
     burst: 200
     period: 1s
     sourceCriterion:
-      ipStrategy:
-        depth: 1
+      # Key rate limiting on the real end-user IP. Public traffic arrives via
+      # Cloudflare tunnel -> cloudflared (plain HTTP, no PROXY/XFF trust), so
+      # XFF is unreliable here; Cloudflare's edge sets CF-Connecting-IP on
+      # every tunneled request. Requests lacking this header (e.g. direct LAN
+      # hits) fall back to a shared bucket — acceptable since CrowdSec + LAN
+      # trust cover that path.
+      requestHeaderName: CF-Connecting-IP

--- a/kubernetes/apps/network/traefik-internal/app/helmrelease.yaml
+++ b/kubernetes/apps/network/traefik-internal/app/helmrelease.yaml
@@ -151,6 +151,15 @@ spec:
     deployment:
       kind: DaemonSet
       revisionHistoryLimit: 3
+      # DaemonSet surge (k8s 1.22+): new pod up before old pod down so every
+      # node keeps a Traefik pod during chart/image bumps. With
+      # externalTrafficPolicy: Local, maxUnavailable>0 blackholes the LB node
+      # mid-rollout. maxSurge:1/maxUnavailable:0 = zero-downtime rollout.
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 0
+          maxSurge: 1
       goMemLimitPercentage: 90
       lifecycle:
         preStop:

--- a/kubernetes/apps/network/traefik-internal/app/networkpolicy.yaml
+++ b/kubernetes/apps/network/traefik-internal/app/networkpolicy.yaml
@@ -24,6 +24,12 @@ spec:
               protocol: TCP
             - port: "443"
               protocol: UDP
+            - port: "5432"  # postgres TCP gateway listener
+              protocol: TCP
+            - port: "514"  # syslog ingest from LAN devices
+              protocol: TCP
+            - port: "514"
+              protocol: UDP
     # Allow intra-cluster traffic (health probes, ServiceMonitor scrapes,
     # pod-to-pod calls if any app ever needs it).
     - fromEntities:
@@ -36,3 +42,7 @@ spec:
               protocol: TCP
             - port: "9100"
               protocol: TCP
+            - port: "514"  # syslog from in-cluster vector DaemonSet
+              protocol: TCP
+            - port: "514"
+              protocol: UDP


### PR DESCRIPTION
- Key rate-limit + CrowdSec on CF-Connecting-IP (XFF unreliable behind CF tunnel)
- Add DaemonSet maxSurge:1/maxUnavailable:0 to both instances (externalTrafficPolicy:Local zero-downtime)
- Open postgres 5432 + syslog 514 in traefik-internal CiliumNetworkPolicy (listeners were being dropped)
- Disable HTTP/3 on traefik-external (CF terminates h3 at edge; was opening UDP/443 on public VIP)
- Remove decommissioned Dolt mysql 3306 listener
- Fix stale rate-limit throughput comment (300 not 180 req/s)