### PR TITLE
fix(ai): GitHub webhook HMAC-SHA256 verification + n8n SA token mount

### DIFF
--- a/kubernetes/apps/ai/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/n8n/app/helmrelease.yaml
@@ -66,6 +66,14 @@ spec:
                   secretKeyRef:
                     name: n8n-loop-sa-token
                     key: token
+              # GitHub HMAC webhook secret — must match the value set in
+              # GitHub Settings → Webhooks for the loop-github-issue hook.
+              # Add GITHUB_WEBHOOK_SECRET to n8n-secrets before deploying.
+              - name: N8N_GITHUB_WEBHOOK_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: n8n-secrets
+                    key: GITHUB_WEBHOOK_SECRET
             envFrom:
               - secretRef:
                   name: n8n-secrets

--- a/kubernetes/apps/ai/n8n/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/n8n/app/secret.sops.yaml
@@ -23,6 +23,7 @@ stringData:
   INIT_POSTGRES_PASS: ENC[AES256_GCM,data:goSuea/CozWVvaeEmNGjCD8lGxD7AWd1ZB03j/S7z3PkFb7INqJp5wWfC0sMzHXZ0WyRiX8JYLVvyAjzQwcx/A==,iv:TjsA/fuoZ471Ws286ZJhZ7Drm7aSqn7X5QKi/UDN/8g=,tag:ChhZX67X+0Djqyz+fViayA==,type:str]
   INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:e8lwYeoAczym+ip9+HA=,iv:+Phlu9e7/5PTeAHcusqSEvgmG4kX3CvPilLKIeROi2Q=,tag:+kUx2is0L06I1Kt1fzHXkw==,type:str]
   INIT_POSTGRES_SUPER_USER: ENC[AES256_GCM,data:xsjaf1LWflw=,iv:fRgEkmSwzYYzPGu96PhV7FGVjxzzi7hd2S3BPzlIIQI=,tag:a4ZFxLN2yIIiF6isUvztfw==,type:str]
+  GITHUB_WEBHOOK_SECRET: ENC[AES256_GCM,data:Xc2w/ZVAObqgvE4q2RIIRfcMzkwPIIOQdi3RyWwY5/a0aP38dBr5r4NVzpA82qBX/6FifAWRyCGIE9+/zTeFwA==,iv:xYsCGDX0jHCDgLQzZSAL72zrWrJry1jpnvyCFYVpGaE=,tag:otUa5kRoxqtzc2rV/7qbaA==,type:str]
 sops:
   age:
     - enc: |
@@ -35,7 +36,7 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age1qwwzsz6z2mmu6hpmjt2he7nepmnhutmhehvkva7l5zy5xzf08d5s5n4d6n
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-05-27T14:22:09Z"
-  mac: ENC[AES256_GCM,data:1cFQO1QQc22ZrldZu5z6WFvprWvKRLOFqG3Y60pS+GesAmRsOAdthFdNVQnvtab1oraO7I6YNn46D3Tu96jovAqiPZg1aQg/t5FW6U2x+MG1a2KeMZBRbZatykzX3nPt28ZG+dgqVMsauHWiCUsl5M2yi6CePk1Td//NfYQHWt8=,iv:84lLugKQafe2dgfSy/sn5ymDE7Cqv1ou7EXXPrgSU7w=,tag:JEjfRvavUm9bP3OLjaWXkQ==,type:str]
+  lastmodified: "2026-06-18T13:50:21Z"
+  mac: ENC[AES256_GCM,data:4GZSILuxaCGyUkMaVdhO7fQYXgsxm7ZGBx05O5JZifkS6DYaWL5MWZZkAyD6n/k8PmVUfZjep1KfzgDF3ZhDg931pfPKJ1KdowfCxSBgBIxh0M1AqKkP4g+c+QmWpQzRXg7JXAmqq/CHzpqaYGQmTdiI+yWDNwEMOPnrNeVgW9Q=,iv:e95bLVdchwQs2xsaPqKRYdR022V9qVtLKKtNmybNhA0=,tag:yoqru+9m/WsCSxNNANW/xg==,type:str]
   mac_only_encrypted: true
   version: 3.13.1

--- a/kubernetes/apps/ai/n8n/workflows/loop-orchestrator.json
+++ b/kubernetes/apps/ai/n8n/workflows/loop-orchestrator.json
@@ -7,13 +7,25 @@
         "path": "loop-github-issue",
         "responseMode": "onReceived",
         "responseData": "allEntries",
-        "options": {}
+        "options": {
+          "rawBody": true
+        }
       },
       "id": "trigger-github",
       "name": "GitHub Issue Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [0, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Verify GitHub webhook HMAC-SHA256 signature.\n// GitHub sends X-Hub-Signature-256: sha256=<hex> over the raw body.\nconst crypto = require('crypto');\nconst item = $input.first();\nconst headers = item.json.headers || {};\nconst rawBody = item.binary?.data\n  ? Buffer.from(item.binary.data, 'base64').toString('utf8')\n  : JSON.stringify(item.json.body);\nconst sigHeader = (headers['x-hub-signature-256'] || '').replace('sha256=', '');\nconst secret = $env.N8N_GITHUB_WEBHOOK_SECRET || '';\nif (!secret) throw new Error('N8N_GITHUB_WEBHOOK_SECRET not set in pod env');\nif (!sigHeader) throw new Error('Missing X-Hub-Signature-256 header');\nconst expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');\nlet valid = false;\ntry {\n  valid = crypto.timingSafeEqual(Buffer.from(sigHeader, 'hex'), Buffer.from(expected, 'hex'));\n} catch(e) { valid = false; }\nif (!valid) throw new Error('GitHub webhook signature invalid');\nreturn [{ json: { body: item.json.body, headers } }];"
+      },
+      "id": "verify-signature",
+      "name": "Verify GitHub Signature",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [120, 0]
     },
     {
       "parameters": {
@@ -384,6 +396,11 @@
   ],
   "connections": {
     "GitHub Issue Webhook": {
+      "main": [
+        [{ "node": "Verify GitHub Signature", "type": "main", "index": 0 }]
+      ]
+    },
+    "Verify GitHub Signature": {
       "main": [
         [{ "node": "Normalize TaskRequest", "type": "main", "index": 0 }]
       ]


### PR DESCRIPTION
## Summary

- **SA token mount**: `n8n-loop-sa-token` Secret auto-populated by K8s, mounted as `$env.N8N_K8S_TOKEN` — no static token needed
- **Webhook HMAC**: `N8N_GITHUB_WEBHOOK_SECRET` env from `n8n-secrets`; webhook node enables `rawBody`; new Verify node uses `crypto.timingSafeEqual` before Normalize

## Manual step before merge

Add `GITHUB_WEBHOOK_SECRET: <value>` to `n8n-secrets`:
```bash
task sops:edit file=kubernetes/apps/ai/n8n/app/secret.sops.yaml
```
Then set the same value in GitHub Settings → Webhooks for the `loop-github-issue` hook.

## Test plan
- [ ] Flux reconciles n8n — pod restarts with new env vars
- [ ] Import updated `loop-orchestrator.json` into n8n
- [ ] Send test webhook with correct signature → passes verify node
- [ ] Send test webhook with wrong signature → n8n throws, returns 500