### PR TITLE
chore(velero): remove loop smoke-test validation comments

### DIFF
--- a/kubernetes/apps/velero/app/kustomization.yaml
+++ b/kubernetes/apps/velero/app/kustomization.yaml
@@ -2,8 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-# loop-validation-2: end-to-end PR + comment test
-# loop-validation: autonomous edit smoke test
 resources:
   - ./namespace.yaml
   - ./secret.sops.yaml


### PR DESCRIPTION
Cleanup of the cosmetic comments inserted by the n8n Loop Orchestrator end-to-end validation runs (issues #452, #454). No functional change.