### PR TITLE
fix(ci): pin ARC charts to 0.14.2, track chart OCI not controller rel…

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/ocirepository.yaml
@@ -10,6 +10,6 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    # renovate: datasource=github-releases depName=actions/actions-runner-controller
-    tag: v0.27.6
+    # renovate: datasource=docker depName=ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
+    tag: 0.14.2
   url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/home-ops/ocirepository.yaml
@@ -10,6 +10,6 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    # renovate: datasource=github-releases depName=actions/actions-runner-controller
-    tag: v0.27.6
+    # renovate: datasource=docker depName=ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
+    tag: 0.14.2
   url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set


### PR DESCRIPTION
…eases

Renovate bumped both gha-runner-scale-set ocirepos to v0.27.6 (the actions-runner-controller APP release tag), but the Helm chart is versioned separately (0.14.x) and v0.27.6 does not exist at the chart OCI path -> 404, reconcile fails. Switch datasource from github-releases to docker pointing at the actual chart OCI repos so Renovate tracks chart tags.