### PR TITLE
ci: run trusted workflows on home-ops self-hosted runner

### DIFF
--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   label-sync:
     name: Label Sync
-    runs-on: ubuntu-latest
+    runs-on: home-ops-runner
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/mise.yaml
+++ b/.github/workflows/mise.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   mise:
     name: upgrade-tools
-    runs-on: ubuntu-latest
+    runs-on: home-ops-runner
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: home-ops-runner
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Move mise, label-sync, and release to runs-on: home-ops-runner. These are dispatch/schedule/push-to-main triggered (trusted). Intentionally NOT moved: labeler (pull_request_target) and validate-secrets (pull_request) keep ubuntu-latest — the runner has cluster-admin + Talos os:admin, so running PR/fork-triggered code on it is a privilege-escalation risk.