### PR TITLE
feat(opencode): wire MCP aggregator, permission guardrails, context limits

### DIFF
--- a/kubernetes/apps/ai/opencode/app/configmap.yaml
+++ b/kubernetes/apps/ai/opencode/app/configmap.yaml
@@ -6,6 +6,18 @@
 # {env:VAR} substitution applied by OpenCode at startup.
 # models block required — without it OpenCode throws ProviderModelNotFoundError
 # even though the provider loads (learned from Kelos task debugging).
+#
+# Per-model `limit.context` mirrors the llama-swap --ctx-size for each slot
+# (source of truth: kubernetes/apps/ai/llama-swap/app/configmap.yaml) so
+# OpenCode truncates history correctly instead of guessing. `limit.output`
+# is a conservative per-turn cap.
+#
+# `mcp` points OpenCode at the in-cluster LiteLLM MCP aggregator (mcpjungle:
+# context7/exa/github/playwright/etc.) — same gateway + virtual key as chat.
+#
+# `permission` is a guardrail: this agent is network-exposed (opencode.68cc.io)
+# and holds a GitHub token on the workspace PVC, so it can run arbitrary shell.
+# bash defaults to "ask"; read/edit/git/task-runner ops are allowed.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,18 +34,63 @@ data:
             "apiKey": "{env:LITELLM_API_KEY}"
           },
           "models": {
-            "local-fast": {"id": "local-fast"},
-            "local-balanced": {"id": "local-balanced"},
-            "local-coder": {"id": "local-coder"},
-            "local-coder-small": {"id": "local-coder-small"},
-            "local-large": {"id": "local-large"},
-            "local-reason": {"id": "local-reason"},
-            "local-reason-agent": {"id": "local-reason-agent"}
+            "local-fast": {
+              "id": "local-fast",
+              "limit": {"context": 8192, "output": 4096}
+            },
+            "local-balanced": {
+              "id": "local-balanced",
+              "limit": {"context": 32768, "output": 8192}
+            },
+            "local-coder": {
+              "id": "local-coder",
+              "limit": {"context": 16384, "output": 8192}
+            },
+            "local-coder-small": {
+              "id": "local-coder-small",
+              "limit": {"context": 32768, "output": 4096}
+            },
+            "local-large": {
+              "id": "local-large",
+              "limit": {"context": 24576, "output": 8192}
+            },
+            "local-reason": {
+              "id": "local-reason",
+              "limit": {"context": 16384, "output": 8192}
+            },
+            "local-reason-agent": {
+              "id": "local-reason-agent",
+              "limit": {"context": 32768, "output": 8192}
+            }
           }
         }
       },
       "model": "litellm/local-coder",
       "small_model": "litellm/local-fast",
+      "mcp": {
+        "litellm": {
+          "type": "remote",
+          "url": "http://litellm.ai.svc.cluster.local:4000/mcp",
+          "enabled": true,
+          "headers": {
+            "Authorization": "Bearer {env:LITELLM_API_KEY}"
+          }
+        }
+      },
+      "permission": {
+        "bash": {
+          "*": "ask",
+          "git *": "allow",
+          "grep *": "allow",
+          "ls *": "allow",
+          "cat *": "allow",
+          "task *": "allow",
+          "kustomize *": "allow",
+          "flux *": "allow"
+        },
+        "edit": "allow",
+        "webfetch": "allow"
+      },
       "autoshare": false,
       "autoupdate": false
     }

--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -56,10 +56,22 @@ spec:
               limits:
                 memory: 1Gi
             probes:
+              # TCP readiness on the web server port so a wedged process is
+              # marked NotReady instead of silently serving nothing. Custom
+              # spec (not the chart's HTTP default) — OpenCode has no documented
+              # health path, so a TCP connect check is the safe signal.
               liveness:
                 enabled: false
               readiness:
-                enabled: false
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 4096
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
               startup:
                 enabled: false
         initContainers:

--- a/kubernetes/apps/ai/opencode/ks.yaml
+++ b/kubernetes/apps/ai/opencode/ks.yaml
@@ -10,10 +10,11 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    # litellm is a hard runtime dep (model gateway). No kelos dep: this is the
+    # interactive web deployment; Kelos drives its OWN opencode runtime in
+    # kelos-system and does not feed this pod.
     - name: litellm
       namespace: *namespace
-    - name: kelos
-      namespace: kelos-system
   interval: 1h
   path: ./kubernetes/apps/ai/opencode/app
   prune: true


### PR DESCRIPTION
## What

Implements #467 — OpenCode config enhancements from the 2026-06-29 AI-stack review. Wires the agent into the cluster's shared MCP catalogue, adds permission guardrails, gives correct per-model context limits, makes the pod observable, and drops a stale reconcile dependency.

## Changes

- **MCP aggregator** (`configmap.yaml`): `mcp.litellm` → `http://litellm.ai.svc.cluster.local:4000/mcp` (`type: remote`, bearer = `LITELLM_API_KEY`). OpenCode now gets the full mcpjungle tool catalogue (context7, exa, github, playwright, …) through the same gateway + key as chat.
- **Permission guardrails** (`configmap.yaml`): `bash` defaults to `ask` with an allow-list for safe read/VCS/task-runner commands (`git/grep/ls/cat/task/kustomize/flux`); `edit` + `webfetch` allowed. The agent is network-exposed (`opencode.68cc.io`) and holds a GitHub token on the workspace PVC, so unrestricted shell was a real risk.
- **Per-model context limits** (`configmap.yaml`): `limit.context`/`limit.output` per model mirror each llama-swap `--ctx-size` so OpenCode truncates history correctly instead of guessing.
- **Readiness probe** (`helmrelease.yaml`): custom TCP probe on `:4096` — a wedged process is now marked NotReady instead of silently serving nothing. (No documented HTTP health path → TCP connect is the safe signal.)
- **Drop stale dep** (`ks.yaml`): removed `dependsOn: kelos`. This interactive web deployment does not consume Kelos (Kelos drives its own opencode runtime in `kelos-system`). Kept the `litellm` runtime dep.

## Verification

- Config schema verified against `opencode.ai/config.json` + docs (mcp `type: remote`, `permission` 3-state, `limit.context`/`limit.output`).
- Embedded `config.json` parses as valid JSON.
- `kustomize build kubernetes/apps/ai/opencode/app` OK.
- `flux-manifest-reviewer` agent: pass (probe syntax matches mosquitto/clickhouse precedent; no new >80-char lines; dependsOn list still valid).

## Notes / follow-ups (not in this PR)

- `{env:...}` interpolation inside `mcp.headers` is documented for `options` but not explicitly for headers — worth a runtime confirm once deployed.
- `bash` allows `flux`/`kustomize` but the pod has no kubeconfig → harmless no-op (kustomize build works offline).
- The "evaluate local-reason-agent (32k) vs local-coder (16k) as default" item from the review is left as an operational A/B, not a config change.

## Refs

#467 — part of epic #470.
