### PR TITLE
feat(kelos): cut concurrency, share coder model, PR-before-close flow

### DIFF
--- a/kubernetes/apps/kelos-system/agents/app/taskspawner-issues.yaml
+++ b/kubernetes/apps/kelos-system/agents/app/taskspawner-issues.yaml
@@ -8,8 +8,12 @@ metadata:
   name: home-ops-issues
   namespace: kelos-system
 spec:
-  maxConcurrency: 2
-  # No lifetime cap — tasks clean up after 24h via ttlSecondsAfterFinished
+  # One GPU; llama-swap chat group is exclusive (one model resident). Cap at 1
+  # here. With the webhook spawner (also 1) that's <=2 total agents, both
+  # pinned to local-coder so they share one resident GGUF (no swap thrash).
+  maxConcurrency: 1
+  # No maxTotalTasks: it is a permanent lifetime cap that bricks an always-on
+  # poller once hit. Runtime is bounded per-task via activeDeadlineSeconds.
 
   when:
     githubIssues:
@@ -22,8 +26,9 @@ spec:
 
   taskTemplate:
     type: opencode
-    # local-reason: Qwen3-30B-A3B-Thinking Q3_K_M — strong reasoning
-    model: litellm/local-reason
+    # local-coder: Qwen3-Coder-30B-A3B Q3_K_M — purpose-built agentic coder.
+    # Shared with the webhook spawner so both reuse one resident GGUF.
+    model: litellm/local-coder
     credentials:
       type: none
     workspaceRef:
@@ -31,6 +36,9 @@ spec:
     agentConfigRefs:
       - name: opencode-local
     ttlSecondsAfterFinished: 86400
+    # Deterministic per-issue branch so concurrent issue tasks never collide
+    # on a shared default branch.
+    branch: "kelos-issue-{{.Number}}"
     promptTemplate: |
       You are working on GitHub Issue #{{.Number}}: {{.Title}}
 
@@ -39,22 +47,35 @@ spec:
 
       Labels: {{.Labels}}
 
-      Repository is cloned at /workspace/repo. Work on the issue, make changes,
-      commit them with a descriptive message referencing the issue number, and push
-      to the branch. Do not close the issue — the PR will handle that.
+      Repository is cloned at /workspace/repo on branch kelos-issue-{{.Number}}.
 
-      Guidelines:
-      - Read CLAUDE.md first for conventions
-      - Run `task sops:verify` before any commit touching *.sops.yaml
-      - Never modify git user config or remote URLs
-      - Prefix commit: fix/feat/chore as appropriate, reference issue in body
-      - Only if the work is complete and verified (kustomize build passes, sops:verify
-        passes, no errors): gh issue close {{.Number}} -R j0sh3rs/home-ops --comment
-        "Completed. Changes pushed to branch."
-      - If incomplete or uncertain, leave the issue open and add a comment explaining
-        what was done and what remains: gh issue comment {{.Number}} -R j0sh3rs/home-ops
+      Workflow:
+      1. Read CLAUDE.md first for conventions.
+      2. Make minimal, targeted changes to address the issue.
+      3. Validate: `kustomize build` on touched paths must pass; run
+         `task sops:verify` before any commit touching *.sops.yaml.
+      4. Commit with a fix/feat/chore prefix; reference the issue in the body.
+      5. Push the branch.
+      6. Open a pull request — do NOT close the issue directly. The merged PR
+         closes it. The PR body MUST contain the literal text "Closes
+         #{{.Number}}" (on its own line) so the merge auto-closes the issue.
+         Write the body with real newlines (use a heredoc or a --body-file,
+         NOT a literal "\n" in a quoted string). Example:
+         gh pr create -R j0sh3rs/home-ops --base main \
+           --head kelos-issue-{{.Number}} \
+           --title "<type>: <summary> (#{{.Number}})" \
+           --body "$(printf 'Closes #{{.Number}}\n\n<what changed and how verified>')"
+
+      Rules:
+      - Never modify git user config or remote URLs.
+      - Never run `gh issue close` — merging the PR closes the issue.
+      - If the work is incomplete or you are uncertain, do NOT open a PR.
+        Leave the issue open and comment what was done and what remains:
+        gh issue comment {{.Number}} -R j0sh3rs/home-ops
         --body "Partial: <summary of what was done and what remains>"
     podOverrides:
+      # Hard runtime ceiling so a wedged agent cannot pin the GPU forever.
+      activeDeadlineSeconds: 3600
       env:
         - name: OPENAI_API_KEY
           valueFrom:

--- a/kubernetes/apps/kelos-system/agents/app/taskspawner-webhook.yaml
+++ b/kubernetes/apps/kelos-system/agents/app/taskspawner-webhook.yaml
@@ -10,7 +10,9 @@ metadata:
   name: home-ops-webhook
   namespace: kelos-system
 spec:
-  maxConcurrency: 2
+  # One GPU; cap at 1. With the issues poller (also 1) that's <=2 total agents,
+  # both on local-coder so they share one resident GGUF (no swap thrash).
+  maxConcurrency: 1
 
   when:
     githubWebhook:
@@ -42,8 +44,9 @@ spec:
 
   taskTemplate:
     type: opencode
-    # local-reason: Qwen3-30B-A3B-Thinking Q3_K_M — stronger reasoning
-    model: litellm/local-reason
+    # local-coder: Qwen3-Coder-30B-A3B Q3_K_M — shared with the issues spawner
+    # so both reuse one resident GGUF (no model swap thrash on the single GPU).
+    model: litellm/local-coder
     credentials:
       type: none
     workspaceRef:
@@ -65,20 +68,34 @@ spec:
       Body: {{.Body}}
       {{- end}}
 
-      Repository cloned at /workspace/repo. Read CLAUDE.md first.
+      Repository cloned at /workspace/repo on branch kelos-{{.Event}}-{{.ID}}.
+      Read CLAUDE.md first.
 
-      Guidelines:
-      - Minimal targeted changes — do not refactor beyond task scope
-      - Run `task sops:verify` before any commit touching *.sops.yaml
-      - Never modify git user config or remote URLs
-      - Commit with fix/feat/chore prefix, reference issue number in body
-      - Only if work is complete and verified (kustomize build passes, sops:verify
-        passes, no errors): gh issue close {{.Number}} -R j0sh3rs/home-ops --comment
-        "Completed. Changes pushed to branch."
-      - If incomplete or uncertain, leave open and comment:
-        gh issue comment {{.Number}} -R j0sh3rs/home-ops --body
+      Workflow:
+      1. Minimal, targeted changes — do not refactor beyond task scope.
+      2. Validate: `kustomize build` on touched paths must pass; run
+         `task sops:verify` before any commit touching *.sops.yaml.
+      3. Commit with a fix/feat/chore prefix; reference the issue number.
+      4. Push the branch.
+      5. Open a pull request — do NOT close the issue directly. The merged PR
+         closes it. The PR body MUST contain the literal text "Closes
+         #{{.Number}}" (on its own line) so the merge auto-closes the issue.
+         Write the body with real newlines (use a heredoc or a --body-file,
+         NOT a literal "\n" in a quoted string). Example:
+         gh pr create -R j0sh3rs/home-ops --base main \
+           --head kelos-{{.Event}}-{{.ID}} \
+           --title "<type>: <summary> (#{{.Number}})" \
+           --body "$(printf 'Closes #{{.Number}}\n\n<what changed and how verified>')"
+
+      Rules:
+      - Never modify git user config or remote URLs.
+      - Never run `gh issue close` — merging the PR closes the issue.
+      - If incomplete or uncertain, do NOT open a PR. Leave the issue open and
+        comment: gh issue comment {{.Number}} -R j0sh3rs/home-ops --body
         "Partial: <summary of what was done and what remains>"
     podOverrides:
+      # Hard runtime ceiling so a wedged agent cannot pin the GPU forever.
+      activeDeadlineSeconds: 3600
       env:
         - name: OPENAI_API_KEY
           valueFrom:


### PR DESCRIPTION
## What

Implements #468 (Kelos hardening from the AI-stack review) and adds the requested **PR-before-close** workflow. Both TaskSpawners — the issues poller and the webhook — are updated.

## Changes

**Concurrency / GPU safety**
- `maxConcurrency` 2 → 1 on each spawner. One GPU; llama-swap `chat` group is exclusive (one model resident). ≤2 total agents across both spawners, both now pinned to `local-coder` so they reuse one resident GGUF (no swap thrash).
- Deliberately **did not** add `maxTotalTasks` — it's a permanent *lifetime* cap (persists across restarts) that would brick an always-on poller once hit. Runtime is bounded per-task instead.
- `podOverrides.activeDeadlineSeconds: 3600` — hard ceiling so a wedged agent can't pin the GPU forever.

**Model wiring fix**
- `model` `litellm/local-reason` → `litellm/local-coder` (Qwen3-Coder-30B-A3B Q3_K_M, the purpose-built agentic coder; was a reasoning model). Also resolves the review's model-wiring conflict: `local-coder` is already in the workspace `config.json` model list; `local-reason-agent` was not.

**Branch collision fix**
- Issues spawner gets a deterministic `branch: kelos-issue-{{.Number}}` (webhook already had a templated branch).

**PR-before-close (the requested change)**
- Both prompt templates rewritten: the agent pushes its branch, runs `gh pr create` with a body containing `Closes #N`, and is explicitly told **never** to run `gh issue close` — the merged PR closes the issue. Incomplete/uncertain work opens no PR and posts a status comment instead.
- PR body uses `printf` for real newlines (not a literal `\n`) so the `Closes #N` keyword lands correctly.

## Why prompt-driven (not a config field)

Verified against `kelos-dev/kelos` v1alpha2 Go types: Kelos has **no native PR-creation field**. PR creation is the agent's job via the `gh` CLI; the `GITHUB_TOKEN` is already present from the workspace secret. `reporting.enabled` only posts status comments — it never opens a PR or closes an issue.

## Verification

- `kustomize build kubernetes/apps/kelos-system/agents/app` OK.
- `flux-manifest-reviewer` pass: field placement (`maxConcurrency`/`branch`/`model` on taskTemplate, `activeDeadlineSeconds` under podOverrides), indentation, and template vars all correct. Caught + fixed a literal-`\n` issue in the PR body.

## Notes / not in this PR

- Webhook `{{.Number}}` is "when available" per Kelos docs — populated for issue/issue_comment/PR events; the auto-close keyword still works.
- Per-spawner caps don't sum-coordinate: if both fire at once you get 2 concurrent agents (acceptable — shared GGUF, just 2× compute contention).
- Webhook HMAC enforcement + port 8443 (the security VERIFY items in #468) are runtime checks against the live GitHub App config, tracked separately — not changeable from these manifests.

## Refs

#468 — part of epic #470.
