### PR TITLE
fix(llama-swap): de-thrash chat group — coder Q3_K_S + router always-on

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -64,13 +64,26 @@ data:
           api_base: http://llama-swap:8080/v1
           api_key: sk-local-llama-swap
 
-      # Agentic coder flagship (Qwen3-Coder-30B-A3B Q3_K_M MoE, 16k ctx)
+      # Agentic coder flagship (Qwen3-Coder-30B-A3B Q3_K_S MoE, 16k ctx).
+      # Default for OpenCode/Kelos: fast MoE decode, reliable tool-calls.
       - model_name: local-coder
         litellm_params:
           model: openai/agentic-coder
           api_base: http://llama-swap:8080/v1
           api_key: sk-local-llama-swap
           max_input_tokens: 16384
+
+      # Heavy coder escalation (Qwen3.6-27B GatedDeltaNet, 8k ctx, RDNA4-only).
+      # Higher coding quality (SWE-bench Verified 77.2) but dense 27B = slower
+      # decode (~20-30 tok/s vs MoE ~150). Use for hard one-shot/visual tasks,
+      # NOT the default agent loop. llama.cpp #22384 checkpoint fix confirmed in
+      # image b9803 — smoke-test multi-turn before relying on it.
+      - model_name: local-coder-heavy
+        litellm_params:
+          model: openai/qwen3.6-27b
+          api_base: http://llama-swap:8080/v1
+          api_key: sk-local-llama-swap
+          max_input_tokens: 8192
 
       # Deep reasoning (Qwen3-30B-A3B-Thinking-2507 Q3_K_M, 16k ctx)
       - model_name: local-reason

--- a/kubernetes/apps/ai/llama-swap/app/configmap.yaml
+++ b/kubernetes/apps/ai/llama-swap/app/configmap.yaml
@@ -12,7 +12,7 @@ data:
     #
     # Navi 48 dGPU on bigboi-jms-01 (Radeon RX 9070 XT, 16 GiB GDDR6, ~640 GB/s).
     # Chat models hot-swap through the 'chat' group (exclusive).
-    # Router + embed + rerank stay resident in 'always-on' (~3 GiB total).
+    # Router + embed + rerank stay resident in 'always-on' (~2.6 GiB total).
     healthCheckTimeout: 180
     logLevel: info
     startPort: 5800
@@ -78,13 +78,17 @@ data:
         ttl: 300
 
       # Agentic coder flagship. Pure-attention qwen3_moe — no GatedDeltaNet/SSM.
-      # Upgraded Q3_K_S → Q3_K_M per whichllm (coding rank #1, score 79.2).
-      # Q3_K_M: ~14.8 GiB; with always-on ~1.3 GiB resident, total ~16.1 GiB.
-      # Tight: run alone, do not raise ctx beyond 16384 on this slot.
+      # Q3_K_S (not Q3_K_M): on-node bench (b9803, 16k ctx, q8_0 KV, FA on)
+      # measured Q3_K_S at 14.19 GB vs Q3_K_M 15.6 GB — gen speed a wash
+      # (152 vs 148 tok/s). The 1.4 GB saved is what lets the coder stay
+      # resident alongside the always-on group (embed+rerank+router/voice
+      # ~2.6 GB): 14.19 + 2.6 = 16.8 < 17.1 GB total. Q3_K_M did not fit
+      # (15.6 + 2.6 = 18.2 > 17.1), forcing a coder eviction on every
+      # router/voice call. This is the #465 de-thrash fix. Keep ctx <=16384.
       "agentic-coder":
         cmd: |
           ${llama-vulkan}
-          --model /models/Qwen3-Coder-30B-A3B-Instruct-Q3_K_M.gguf
+          --model /models/Qwen3-Coder-30B-A3B-Instruct-Q3_K_S.gguf
           --ctx-size 16384
           --temp 0.6 --top-p 0.95
         aliases:
@@ -188,8 +192,10 @@ data:
 
       # ==================== ALWAYS-ON GROUP (no swap) ====================
 
-      # Fast router — moved to chat swap group to reclaim 1.4 GiB VRAM for
-      # Qwen3.6-27B Q3_K_S (11.8 GiB). Accessible via fast/small/router aliases.
+      # Fast router + HA/voice model. Always-on (persistent): with the coder at
+      # Q3_K_S there is room to keep this resident (~1.3 GiB) so routing,
+      # title-gen (opencode small_model) and Home Assistant voice never evict
+      # the resident coder. Accessible via fast/small/router aliases.
       # Caller system prompt should include /no_think to suppress CoT.
       "qwen3-1.7b":
         cmd: |
@@ -242,7 +248,6 @@ data:
         swap: true
         exclusive: true
         members:
-          - "qwen3-1.7b"
           - "qwen3-8b"
           - "agentic-coder"
           - "reasoner"
@@ -251,9 +256,10 @@ data:
           - "qwen3-14b"
           - "qwen3.6-27b"
 
-      # Always-on: embed + rerank only. ~1.3 GiB resident (was ~3 GiB with router).
-      # qwen3-1.7b moved to chat swap to free 1.4 GiB for Qwen3.6-27B.
-      # persistent: true = preloaded at startup, not on first request.
+      # Always-on: embed + rerank + fast router/voice. ~2.6 GiB resident.
+      # qwen3-1.7b is back here (coder is now Q3_K_S, freeing the headroom) so
+      # routing, opencode small_model title-gen, and HA voice never evict the
+      # resident coding model. persistent: true = preloaded at startup.
       "always-on":
         swap: false
         exclusive: false
@@ -261,3 +267,4 @@ data:
         members:
           - "qwen3-embed"
           - "qwen3-rerank"
+          - "qwen3-1.7b"

--- a/kubernetes/apps/ai/llama-swap/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-swap/app/helmrelease.yaml
@@ -114,13 +114,14 @@ spec:
                   "https://huggingface.co/bartowski/Qwen2.5-Coder-3B-GGUF/resolve/main/Qwen2.5-Coder-3B-Q5_K_M.gguf?download=true" \
                   "Qwen2.5-Coder-3B-Q5_K_M.gguf" \
                   2100000000
-                # Qwen3-Coder-30B-A3B-Instruct Q3_K_M (~14.8 GiB) — agentic coder
-                # Upgraded Q3_K_S → Q3_K_M per whichllm (coding rank #1, 79.2).
-                # Tight on 16 GiB with always-on; keep ctx ≤16384 on this slot.
+                # Qwen3-Coder-30B-A3B-Instruct Q3_K_S (~13.3 GiB) — agentic coder
+                # Q3_K_S not Q3_K_M: bench showed gen speed a wash but Q3_K_S
+                # frees ~1.4 GiB so the coder stays resident alongside the
+                # always-on group (embed+rerank+router/voice). #465 de-thrash.
                 fetch \
-                  "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/resolve/main/Qwen3-Coder-30B-A3B-Instruct-Q3_K_M.gguf?download=true" \
-                  "Qwen3-Coder-30B-A3B-Instruct-Q3_K_M.gguf" \
-                  14500000000
+                  "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/resolve/main/Qwen3-Coder-30B-A3B-Instruct-Q3_K_S.gguf?download=true" \
+                  "Qwen3-Coder-30B-A3B-Instruct-Q3_K_S.gguf" \
+                  13300000000
                 # Qwen3-30B-A3B-Thinking-2507 Q3_K_M (~13.1 GiB) — deep reasoner
                 # Upgraded Q3_K_S → Q3_K_M per whichllm. Keep ctx ≤16384.
                 # bartowski file actual size 13.11 GiB; threshold corrected.


### PR DESCRIPTION
## What

Actually implements the #465 de-thrash. The issue was closed COMPLETED but the fix never landed — worse, a prior change (`285c3e57`) moved `qwen3-1.7b` the **wrong** way (into the exclusive swap group) to make VRAM room for Qwen3.6-27B, which is the exact thrash #465 was filed to prevent.

## Bench-driven decision

The blocker was a hard VRAM wall: `agentic-coder` Q3_K_M (15.6 GB) + always-on group (~2.6 GB) = 18.2 GB > 17.1 GB total. Something had to give. Ran an on-node bench (bigboi, image b9803, 16k ctx, q8_0 KV, FA on):

| quant | VRAM (coder) | gen tok/s | prefill tok/s |
|---|---|---|---|
| Q3_K_M (was) | 15.6 GB | 148 | 253 |
| **Q3_K_S (now)** | **14.19 GB** | **152** | 233 |

Gen speed is a **wash**; Q3_K_S frees ~1.4 GB — exactly enough to keep the coder resident alongside the always-on group: `14.19 + 2.6 = 16.8 < 17.1`. Q3_K_M could not (`18.2`), forcing a coder eviction on every router/voice call.

## Changes

- **agentic-coder Q3_K_M → Q3_K_S**: configmap cmd, init-container fetch URL/filename, and min-bytes guard (14.5G → 13.3G). Filename consistency verified (cmd ↔ fetch ↔ live PVC).
- **qwen3-1.7b moved OUT of exclusive `chat` → persistent `always-on`** (now embed + rerank + qwen3-1.7b). Routing, OpenCode `small_model` title-gen, and Home Assistant voice no longer evict the resident coder. This is the actual de-thrash, and it pre-positions the fast model for the upcoming HA voice work.
- **litellm: add `local-coder-heavy` → qwen3.6-27b**. Exposes the frontier coder (was unreachable — in no LiteLLM model_list). Higher quality (SWE-bench Verified 77.2) but dense 27B decodes ~20–30 tok/s vs the MoE's ~150 — so it's an escalation slot for hard one-shot/visual tasks, explicitly NOT the default agent loop. llama.cpp #22384 hybrid-checkpoint fix confirmed present in b9803 (smoke-test multi-turn before relying on it).
- Stale comment fixes (always-on ~3 → ~2.6 GiB; local-coder Q3_K_M → Q3_K_S).

## Why keep the catalogue mostly intact

I considered dropping `reasoner` and `qwen3-14b` (review suggested it) but **didn't**: swap-group members cost zero resident VRAM (one loads at a time), so removing them doesn't help the goal — and they're live LiteLLM fallback targets (`local-reason`, `local-large`) plus the dense safety-floor. Cutting them would break fallback chains for no VRAM gain.

## Verification

- On-node bench (above) — real VRAM + tok/s, not estimates.
- `kustomize build` both app dirs OK.
- `flux-manifest-reviewer` pass: filename consistency (no fresh-PVC load failure), group integrity (no dup/orphan), fetch guard < real file size, `local-coder-heavy` → real llama-swap key.

## Notes

- Qwen3.6-27B for multi-turn agentic use is gated on a smoke test (`restored context checkpoint` log line on turn 2) before trusting it — flagged in the config comment.

## Refs

Implements #465 (part of epic #470). Issue was already closed; this is the real landing.
