### PR TITLE
fix(llama-swap): raise HelmRelease timeout to 30m for cold model fetch

### DIFF
--- a/kubernetes/apps/ai/llama-swap/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-swap/app/helmrelease.yaml
@@ -10,6 +10,12 @@ spec:
   chartRef:
     kind: OCIRepository
     name: app-template
+  # First-boot (or new-model) reconciles block on the model-fetch init
+  # container pulling up to ~60 GiB of GGUFs off HuggingFace into the RWO
+  # PVC. The Helm default 5m timeout trips long before that completes,
+  # failing the release and rolling back to a config that references a
+  # not-yet-downloaded file. 30m covers a cold multi-model fetch.
+  timeout: 30m
   install:
     remediation:
       retries: 3


### PR DESCRIPTION
## What

Fixes the failed/rolled-back llama-swap HelmRelease that broke local-coder (and therefore the Kelos/OpenCode agent loops) after #474 merged.

## Root cause

#474 pointed `agentic-coder` at a new GGUF (`Qwen3-Coder-30B-A3B-Instruct-Q3_K_S.gguf`) that wasn't yet on the PVC. The reconcile triggered the `model-fetch` init container to download it (~13.7G off HuggingFace), but the HelmRelease has **no `spec.timeout`** → Helm's 5m default. The download blew past 5m → `timeout waiting for: Deployment/ai/llama-swap status: 'InProgress'` → 4 failed attempts → `Stalled` → **rollback to v61**.

The reloader-managed ConfigMap updated independently, so the surviving (rolled-back) pod served a config referencing a file that only existed as a partial `*.part`. Result: `agentic-coder exited: upstream command exited prematurely` → HTTP 500 on every `local-coder` call → Kelos/OpenCode agents hung waiting on the coder.

## Fix

- `spec.timeout: 30m` — covers a cold multi-model fetch (the init container pulls up to ~60 GiB across all models on a fresh PVC). Prevents the Helm window from tripping on legitimate first-boot/new-model downloads.

## Companion manual step (done out-of-band)

The Q3_K_S GGUF is being pre-seeded directly into the live PVC (removing the stale `.part`) so the currently-running pod recovers immediately without waiting for a full reconcile. This PR prevents recurrence; the seed unblocks today.

## Verification

- `kustomize build kubernetes/apps/ai/llama-swap/app` OK.
- Root cause confirmed from live cluster: HR `Stalled=True: Failed to upgrade after 4 attempt(s)`, `Released=False: ... timeout waiting for ... InProgress`, and the partial `Qwen3-Coder-30B-A3B-Instruct-Q3_K_S.gguf.part` (5.0G) on the PVC.

## Refs

#465 (the de-thrash that introduced the new GGUF), #470.
