### PR TITLE
fix(kelos): correct mcpjungle port, cross-ns netpol, renovate annotation (#468)

### DIFF
--- a/kubernetes/apps/ai/mcpjungle/app/kustomization.yaml
+++ b/kubernetes/apps/ai/mcpjungle/app/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - ./configmap.yaml
   - ./bootstrap-job.yaml
   - ./secret.sops.yaml
+  - ./networkpolicy-kelos.yaml
 components:
   - ../../../../components/repos/app-template

--- a/kubernetes/apps/ai/mcpjungle/app/networkpolicy-kelos.yaml
+++ b/kubernetes/apps/ai/mcpjungle/app/networkpolicy-kelos.yaml
@@ -1,0 +1,24 @@
+---
+# Allow Kelos Task pods (kelos-system) to reach mcpjungle on port 8080.
+# Without this, Cilium drops the cross-namespace connection and AgentConfig
+# MCP calls fail silently. Same pattern as dragonflydb-allow-cross-ns-clients
+# in the databases namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kelos-to-mcpjungle
+  namespace: ai
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: mcpjungle
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kelos-system
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/kubernetes/apps/kelos-system/agents/app/agentconfig-opencode.yaml
+++ b/kubernetes/apps/kelos-system/agents/app/agentconfig-opencode.yaml
@@ -12,7 +12,8 @@ spec:
   agentsMD: |
     # Home-ops Kelos Agent
 
-    You are an AI coding assistant running inside the home-ops Kubernetes cluster.
+    You are an AI coding assistant running inside the
+    home-ops Kubernetes cluster.
     You have access to the local git repository mounted at /workspace/repo.
 
     ## Guidelines
@@ -25,7 +26,7 @@ spec:
   mcpServers:
     - name: github
       type: http
-      url: "http://mcpjungle.ai.svc.cluster.local:3000/github"
+      url: "http://mcpjungle.ai.svc.cluster.local:8080/github"
     - name: context7
       type: http
-      url: "http://mcpjungle.ai.svc.cluster.local:3000/context7"
+      url: "http://mcpjungle.ai.svc.cluster.local:8080/context7"

--- a/kubernetes/apps/kelos-system/kelos/app/helmrelease.yaml
+++ b/kubernetes/apps/kelos-system/kelos/app/helmrelease.yaml
@@ -41,6 +41,6 @@ spec:
 
     # Agent images — pin to match Kelos release.
     # kelos-dev/opencode bundles OpenCode with the Kelos entrypoint wrapper.
-    # renovate: datasource=github-releases depName=kelos-dev/kelos
+    # renovate: datasource=docker depName=ghcr.io/kelos-dev/opencode
     agentImages:
       opencodeImage: ghcr.io/kelos-dev/opencode:v0.42.0


### PR DESCRIPTION
## What

Remaining open items from #468 not covered by #473.

## Changes

**mcpjungle port fix** (`agentconfig-opencode.yaml`)
- MCP server URLs: port `3000` → `8080` (confirmed via `kubectl get svc -n ai
  mcpjungle`). With the wrong port, all AgentConfig MCP calls would fail
  silently at the TCP level.

**Cross-ns NetworkPolicy** (`ai/mcpjungle/app/networkpolicy-kelos.yaml`)
- Adds `allow-kelos-to-mcpjungle` in `ai` namespace permitting
  `kelos-system` Task pods → `mcpjungle:8080` ingress. Cilium drops
  cross-namespace traffic by default; same pattern as
  `dragonflydb-allow-cross-ns-clients`.

**Renovate annotation fix** (`kelos/app/helmrelease.yaml`)
- `opencodeImage` annotation: `datasource=github-releases
  depName=kelos-dev/kelos` → `datasource=docker
  depName=ghcr.io/kelos-dev/opencode`. Previous annotation was
  tracking the Kelos chart releases, not the OpenCode container image.

## Verification

- `kustomize build kubernetes/apps/ai/mcpjungle/app` — clean
- `kustomize build kubernetes/apps/kelos-system/agents/app` — clean
- pre-commit hooks pass (yamllint, secret scan)
- Port confirmed: `kubectl get svc -n ai mcpjungle` → `8080/TCP`

## Not in this PR (runtime-only checks)

- Webhook HMAC enforcement: `WEBHOOK_SECRET` is provisioned in
  `kelos-github-secret` (encrypted); runtime enforcement is inside the
  Kelos binary, not configurable from manifests.
- Controller OOMKill risk at 256Mi: monitoring concern, not a manifest
  fix — revisit if we see OOMKill events under informer load.
- PAT vs GitHub App precedence: both are provisioned; Kelos picks
  GitHub App when all three App fields are set (App ID + Installation
  ID + Private Key present in secret). PAT stays as fallback per
  kelos-dev docs. Removing it requires confirming App-only mode works
  end-to-end first.

Closes #468