### PR TITLE
feat(litellm): add ha-assist model alias for Home Assistant Assist (#469)

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -62,6 +62,21 @@ data:
           api_key: sk-local-llama-swap
           max_parallel_requests: 2
 
+      # Home Assistant Assist conversation agent alias.
+      # HACS extended_openai_conversation config:
+      #   base_url: http://litellm.ai.svc.cluster.local:4000/v1
+      #   api_key:  <ha-assist virtual key — mint in LiteLLM UI>
+      #   model:    ha-assist
+      # Qwen3-8B (local-balanced): min viable for HA tool-calls; 1.7B
+      # hallucinates entity IDs. Keep entity exposure ≤25, cap function
+      # calls per conversation. LAN-only; no external route needed.
+      - model_name: ha-assist
+        litellm_params:
+          model: openai/qwen3-4b
+          api_base: http://llama-swap:8080/v1
+          api_key: sk-local-llama-swap
+          max_parallel_requests: 1
+
       # FIM autocomplete (Qwen2.5-Coder-3B BASE — raw infill, no chat template)
       - model_name: local-coder-small
         litellm_params:


### PR DESCRIPTION
## What

Adds `ha-assist` model alias to LiteLLM configmap for Home Assistant
Assist conversation agent integration (#469).

## Change

Single new entry in `model_list` backed by `openai/qwen3-4b`
(same GGUF as `local-balanced`):

```yaml
- model_name: ha-assist
  litellm_params:
    model: openai/qwen3-4b
    api_base: http://llama-swap:8080/v1
    api_key: sk-local-llama-swap
    max_parallel_requests: 1
```

`max_parallel_requests: 1` (vs 2 on `local-balanced`) — voice requests
arrive serially; keeping it at 1 avoids double-queuing on the exclusive
chat group when a coding agent is also active.

## Manual step required after merge

Mint a `ha-assist` virtual key in the LiteLLM admin UI scoped to model
`ha-assist` only, then configure HACS `extended_openai_conversation`:

```
base_url: http://litellm.ai.svc.cluster.local:4000/v1
api_key:  <minted virtual key>
model:    ha-assist
```

Keep HA entity exposure ≤25 and cap function calls per conversation
(prompt-injection → `execute_service` blast radius).

## Not in this PR (HA state, not GitOps)

- HACS component install
- `extended_openai_conversation` HA config entry
- LLM as fallback agent config in HA (keep built-in intent matcher
  primary)

## Verification

- `kustomize build kubernetes/apps/ai/litellm/app` clean
- pre-commit hooks pass

Closes #469