### PR TITLE
fix(opencode): refresh git remote URL with token on pod restart (#487)

### DIFF
--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -97,11 +97,14 @@ spec:
               - sh
               - -c
               - |
+                REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/j0sh3rs/home-ops.git"
                 if [ ! -d /workspace/home-ops/.git ]; then
-                  git clone https://x-access-token:${GITHUB_TOKEN}@github.com/j0sh3rs/home-ops.git /workspace/home-ops
+                  git clone "$REMOTE" /workspace/home-ops
                   git -C /workspace/home-ops config user.name "OpenCode"
                   git -C /workspace/home-ops config user.email "opencode@68cc.io"
                 else
+                  # Refresh remote URL so token is current after pod restart.
+                  git -C /workspace/home-ops remote set-url origin "$REMOTE"
                   git -C /workspace/home-ops fetch --quiet
                 fi
             envFrom:


### PR DESCRIPTION
## Root cause

On pod restart, `repo-init` took the `else` branch and ran
`git fetch` against the stored remote URL — which has no token
embedded. Push (and authenticated fetch) failed with auth errors.

## Fix

Always call `git remote set-url origin` with the current
`GITHUB_TOKEN` before fetch, so the credential is live regardless
of restart count:

```sh
REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/j0sh3rs/home-ops.git"
...
else
  git -C /workspace/home-ops remote set-url origin "$REMOTE"
  git -C /workspace/home-ops fetch --quiet
fi
```

## Verification

- `kustomize build kubernetes/apps/ai/opencode/app` clean
- pre-commit hooks pass

Closes #487