### PR TITLE
feat(opencode): codify skill + plugin install + Renovate tracking (#486)

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -66,5 +66,38 @@
       // the prefix when generating the comparison so Renovate matches.
       extractVersionTemplate: "^v?(?<version>.+)$",
     },
+    {
+      customType: "regex",
+      description: "OpenCode skill bundles in opencode-skills-manifest (#486)",
+      // bundles.txt lines: <name> <github-url> <ref> <subdir>. The space-
+      // delimited format does not fit the generic `# renovate:` manager, so
+      // match the line directly (CNPG/.mise.toml precedent). Captures the
+      // owner/repo as depName and the pinned ref as currentValue; comment
+      // lines have no `https://github.com/<o>/<r> <ver> <subdir>` shape so
+      // they are skipped.
+      fileMatch: [
+        "(^|/)kubernetes/apps/ai/opencode/app/skills-install\\.ya?ml$",
+      ],
+      matchStrings: [
+        "\\S+ https://github\\.com/(?<depName>[^/\\s]+/[^/\\s]+) (?<currentValue>\\S+) \\S+",
+      ],
+      datasourceTemplate: "github-releases",
+      versioningTemplate: "semver",
+    },
+    {
+      customType: "regex",
+      description: "OpenCode npm plugins in config.json plugin[] array (#486)",
+      // Matches a pinned scoped npm package "@scope/name@version" inside the
+      // embedded config.json. The required @version suffix excludes the
+      // unversioned provider entries (@ai-sdk/openai-compatible, etc.).
+      fileMatch: [
+        "(^|/)kubernetes/apps/ai/opencode/app/configmap\\.ya?ml$",
+      ],
+      matchStrings: [
+        "\"(?<depName>@[^\"@]+/[^\"@]+)@(?<currentValue>[^\"]+)\"",
+      ],
+      datasourceTemplate: "npm",
+      versioningTemplate: "npm",
+    },
   ],
 }

--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -194,6 +194,21 @@
       },
     },
     {
+      description: "OpenCode Extensions - skill bundles + npm plugins (#486)",
+      groupName: "OpenCode Extensions",
+      matchDatasources: ["github-releases", "npm"],
+      matchPackageNames: [
+        "JuliusBrussee/caveman",
+        "affaan-m/ECC",
+        "@franlol/opencode-md-table-formatter",
+      ],
+      stabilityDays: 3,
+      labels: ["type/app", "risk/low"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+    },
+    {
       description: "llama-swap: only allow vulkan-b tagged builds",
       matchPackageNames: ["ghcr.io/mostlygeek/llama-swap"],
       allowedVersions: "/.*-vulkan-b.*/",

--- a/kubernetes/apps/ai/opencode/app/configmap.yaml
+++ b/kubernetes/apps/ai/opencode/app/configmap.yaml
@@ -18,6 +18,14 @@
 # `permission` is a guardrail: this agent is network-exposed (opencode.68cc.io)
 # and holds a GitHub token on the workspace PVC, so it can run arbitrary shell.
 # bash defaults to "ask"; read/edit/git/task-runner ops are allowed.
+#
+# `plugin` lists npm-published OpenCode plugins. OpenCode's bundled Bun fetches
+# them at startup into the (ephemeral) config node_modules — no extra runtime in
+# the image. Only zero-dependency plugins belong here: ones needing a system
+# binary (git, firecrawl-cli), Bun-native bindings (bun-pty), or external
+# accounts (supermemory) cannot run in this single-binary image and are tracked
+# as deferred in issue #486. File-based SKILL.md bundles install separately via
+# the skills-init container (see skills-install.yaml).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -67,6 +75,9 @@ data:
       },
       "model": "litellm/local-coder",
       "small_model": "litellm/local-fast",
+      "plugin": [
+        "@franlol/opencode-md-table-formatter@0.0.6"
+      ],
       "mcp": {
         "litellm": {
           "type": "remote",

--- a/kubernetes/apps/ai/opencode/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/opencode/app/helmrelease.yaml
@@ -107,6 +107,55 @@ spec:
             envFrom:
               - secretRef:
                   name: opencode-secrets
+          # Install external skill bundles into the (ephemeral) config skills
+          # dir on every boot — issue #486. Source of truth is the
+          # opencode-skills-manifest ConfigMap (skills-install.yaml). OpenCode
+          # reads skills from ~/.config/opencode/skills/<name>/SKILL.md. This
+          # runs after config-init populates the dir and is idempotent: each
+          # bundle is shallow-cloned at its pinned ref and the skill subtree is
+          # copied in. A clone failure for one bundle is logged and skipped so
+          # a single bad ref does not wedge pod startup.
+          skills-init:
+            # Explicit ordering — runs after config-init creates the config
+            # dir. Without this the chart orders init containers alphabetically,
+            # which only happens to be correct today.
+            dependsOn: config-init
+            image:
+              repository: alpine/git
+              tag: v2.54.0
+            command:
+              - sh
+              - -c
+              - |
+                set -u
+                SKILLS_DIR=/root/.config/opencode/skills
+                mkdir -p "$SKILLS_DIR"
+                # Strip comments/blanks, then read: name url ref subdir
+                grep -vE '^\s*(#|$)' /manifest/bundles.txt | while read -r name url ref subdir; do
+                  [ -z "$name" ] && continue
+                  tmp=$(mktemp -d)
+                  echo "[skills-init] $name @ $ref"
+                  if ! git clone --depth 1 --branch "$ref" --quiet "$url" "$tmp"; then
+                    echo "[skills-init] WARN: clone failed for $name ($url@$ref), skipping" >&2
+                    rm -rf "$tmp"; continue
+                  fi
+                  if [ ! -d "$tmp/$subdir" ]; then
+                    echo "[skills-init] WARN: $subdir/ missing in $name, skipping" >&2
+                    rm -rf "$tmp"; continue
+                  fi
+                  count=0
+                  for skill in "$tmp/$subdir"/*/; do
+                    [ -d "$skill" ] || continue
+                    [ -f "$skill/SKILL.md" ] || continue
+                    sname=$(basename "$skill")
+                    rm -rf "$SKILLS_DIR/$sname"
+                    cp -a "$skill" "$SKILLS_DIR/$sname"
+                    count=$((count + 1))
+                  done
+                  echo "[skills-init] $name: installed $count skills"
+                  rm -rf "$tmp"
+                done
+                echo "[skills-init] total in $SKILLS_DIR: $(ls -1 "$SKILLS_DIR" | wc -l)"
 
     service:
       app:
@@ -148,6 +197,12 @@ spec:
         name: opencode-config
         globalMounts:
           - path: /configmap
+      # Skill-bundle manifest (read-only) — consumed by skills-init.
+      manifest:
+        type: configMap
+        name: opencode-skills-manifest
+        globalMounts:
+          - path: /manifest
       # Workspace PVC — OpenCode writes session data and tool outputs here
       workspace:
         type: persistentVolumeClaim

--- a/kubernetes/apps/ai/opencode/app/kustomization.yaml
+++ b/kubernetes/apps/ai/opencode/app/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./configmap.yaml
+  - ./skills-install.yaml
   - ./helmrelease.yaml
   - ./secret.sops.yaml

--- a/kubernetes/apps/ai/opencode/app/skills-install.yaml
+++ b/kubernetes/apps/ai/opencode/app/skills-install.yaml
@@ -1,0 +1,45 @@
+---
+# Idempotent OpenCode skill installer (issue #486).
+#
+# WHY THIS EXISTS: OpenCode's config dir (/root/.config/opencode) is an
+# emptyDir — it is wiped on every pod restart and does NOT survive PVC loss.
+# Anything not replayed from git on boot is gone. This ConfigMap is the
+# git-codified source of truth for which external skill bundles get installed;
+# the `skills-init` init container (helmrelease.yaml) reads it and materializes
+# each bundle's `skills/<name>/SKILL.md` tree into the config skills dir.
+#
+# OpenCode reads skills from ~/.config/opencode/skills/<name>/SKILL.md
+# (verified from the bundled binary's own help text + path strings). The
+# SKILL.md frontmatter format is shared with Claude Code, so these bundles
+# drop in as plain files with no plugin/runtime dependency.
+#
+# Plugins are handled separately via the `plugin: [...]` array in
+# configmap.yaml (OpenCode's internal Bun fetches them from npm at startup).
+# Only file-based skills are installed here.
+#
+# TO ADD/REMOVE a bundle: edit the `bundles` list below. To bump a version,
+# change the ref. The init container is fully idempotent: it re-clones at the
+# pinned ref each boot and rsync-mirrors the skills dir.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opencode-skills-manifest
+data:
+  # One bundle per line: <name> <git-url> <ref> <subdir-containing-skills>
+  # The init container clones each at <ref> (shallow), then copies every
+  # <subdir>/<skill>/ dir into ~/.config/opencode/skills/. A leading '#'
+  # comments a line out without deleting it.
+  #
+  # VERSION BUMPS ARE MANUAL. The repo's renovate customManager matches
+  # `key: value` / `key=value` lines, not this space-delimited format, so an
+  # inline `# renovate:` comment here would silently never fire. Bump the
+  # <ref> field by hand after checking upstream releases:
+  #   gh release view -R JuliusBrussee/caveman --json tagName -q .tagName
+  #   gh release view -R affaan-m/ECC          --json tagName -q .tagName
+  bundles.txt: |
+    # caveman: ultra-compressed comms + cavecrew subagents (7 skills, ~116K).
+    caveman https://github.com/JuliusBrussee/caveman v1.9.0 skills
+    # ECC: large multi-domain skill library (~277 skills, ~4M). Trim the
+    # canonical skills/ tree upstream-side if the picker gets noisy; ECC
+    # enforcement is degraded under OpenCode (no executable-hook parity).
+    ecc https://github.com/affaan-m/ECC v2.0.0 skills


### PR DESCRIPTION
## Summary

Addresses #486 — codify a repeatable, PVC-loss-surviving install of OpenCode skills and plugins, with Renovate auto-bumping.

OpenCode's config dir (`/root/.config/opencode`) is an `emptyDir` — wiped on every pod restart and lost with the PVC. Anything not replayed from git on boot is gone. This makes skill/plugin install repeatable and idempotent.

## What's included

**Install mechanism (`ca5b7db7`)**
- `skills-install.yaml` — new `opencode-skills-manifest` ConfigMap, git-codified source of truth for skill bundles: caveman `v1.9.0`, ECC `v2.0.0` (`<name> <url> <ref> <subdir>`).
- `helmrelease.yaml` — `skills-init` initContainer (alpine/git): reads the manifest, shallow-clones each bundle at its pinned ref, mirrors `SKILL.md` dirs into `~/.config/opencode/skills/`. `dependsOn: config-init` for explicit ordering; per-bundle clone failures logged + skipped so one bad ref can't wedge startup.
- `configmap.yaml` — `plugin[]` array with `@franlol/opencode-md-table-formatter@0.0.6` (zero-dep npm plugin; OpenCode's bundled Bun fetches at startup).

**Renovate tracking (`b328157d`)**
- `customManagers.json5` — two regex managers matching the lines directly (CNPG/`.mise.toml` precedent): skills → `github-releases`, plugin → `npm`.
- `groups.json5` — "OpenCode Extensions" group, 3-day stability, `type/app`+`risk/low`. Inherits global minor/patch automerge; majors stay blocked.

## Categorization (issue steps 1–3)

Full 12-item compat matrix posted as an [issue comment](https://github.com/j0sh3rs/home-ops/issues/486#issuecomment-4847234590). Only mechanically-valid items shipped.

**Deferred with reason** — the single-binary image has no `git`/`node`/`bun`/`python`/CLI in PATH, so these would silently fail at runtime:
- git-dependent plugins (conductor, worktree), bun-native (pty), external-binary (firecrawl-cli), python proxy (headroom), ocx-registry bundles (workspace, oh-my-openagent).
- Enabling them needs an image change or sidecar → separate issue.

## Validation

- `kustomize build` ✓; `helm template` against app-template 4.6.2 ✓ (init order `config-init`→`repo-init`→`skills-init`, `/manifest` + skills dir mounts confirmed).
- Embedded `config.json` valid JSON ✓; `bundles.txt` parses to exactly 2 bundles ✓.
- flux-manifest-reviewer ✓ (no blockers).
- `renovate-config-validator` ✓ all 3 config files; both regexes tested against real files (correct depName/currentValue, no false positives on `@ai-sdk/*`).

## Test plan (post-merge, step 5)

After Flux reconciles:
- [ ] `kubectl -n ai logs <opencode-pod> -c skills-init` → "installed N skills" lines, no WARN
- [ ] `kubectl -n ai get pods -l app.kubernetes.io/name=opencode` → Running, no init crashloop
- [ ] Confirm skills visible in OpenCode + md-table plugin loaded (`node_modules` populated)

## Open question

`md-table-formatter` is pre-1.0 (`0.0.6`) — under semver, `0.0.6→0.1.0` is "minor" so it **will** automerge despite pre-1.0 minors being potentially breaking. Matches the "automerge whenever available" ask; flag if you'd rather gate 0.x minors for review.