### PR TITLE
feat(ci): add flate render/diff CI gate + konflate PR review dashboard

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -60,6 +60,11 @@ jobs:
       - name: flate diff
         id: diff
         continue-on-error: true
+        env:
+          # flate/action always exports FLATE_BASE (default: the default
+          # branch); it collides with the --path-orig baseline we manage
+          # ourselves above ("--path-orig and --base are mutually exclusive").
+          FLATE_BASE: ""
         run: |
           flate diff all \
             --path ./kubernetes \
@@ -70,6 +75,11 @@ jobs:
 
       - name: flate test
         id: test
+        env:
+          # Same as above: run full-tree, not the action's implicit
+          # changed-only mode (which mis-resolved a HelmRepository
+          # dependency ordering for kube-system/amd-gpu in practice).
+          FLATE_BASE: ""
         run: |
           flate test all \
             --path ./kubernetes \

--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -1,0 +1,99 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Flux Diff
+
+# Renders the Flux cluster at the PR/branch head and at its baseline with flate
+# (https://github.com/home-operations/flate), diffs the two, and runs flate's
+# built-in reconcile test suite. The job's pass/fail becomes the "Flux Diff"
+# check that Renovate's autoMerge rules wait on (see .renovate/autoMerge.json5,
+# ignoreTests: false).
+#
+# Two triggers are required to cover both merge paths on this repo:
+#   - pull_request: human-opened PRs and any Renovate PR that needs a PR for
+#     visibility (autoMerge.json5 "Helm chart updates" rule).
+#   - push to renovate/**: Renovate's default automergeType is "branch", which
+#     merges straight into main without ever opening a PR — the check still
+#     needs to land on that branch's HEAD commit for ignoreTests:false to gate it.
+on:
+  pull_request:
+    paths:
+      - "kubernetes/**/*.yaml"
+      - ".github/workflows/flux-diff.yaml"
+  push:
+    branches:
+      - "renovate/**"
+    paths:
+      - "kubernetes/**/*.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  flux-diff:
+    name: Render and Diff
+    runs-on: home-ops-runner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup flate
+        uses: home-operations/flate/action@0fc37fae10cf3c265294f6adebc6d6c100c74ea5  # v0.4.10
+        with:
+          cache: true
+
+      - name: Materialize baseline tree
+        id: baseline
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}"
+          git fetch origin "${BASE_REF}"
+          MERGE_BASE=$(git merge-base HEAD "origin/${BASE_REF}")
+          git worktree add /tmp/flate-baseline "${MERGE_BASE}"
+          echo "dir=/tmp/flate-baseline" >> "${GITHUB_OUTPUT}"
+
+      - name: flate diff
+        id: diff
+        continue-on-error: true
+        run: |
+          flate diff all \
+            --path ./kubernetes \
+            --path-orig "${{ steps.baseline.outputs.dir }}/kubernetes" \
+            --allow-missing-secrets \
+            --api-versions monitoring.coreos.com/v1 \
+            -o github > diff.md
+
+      - name: flate test
+        id: test
+        run: |
+          flate test all \
+            --path ./kubernetes \
+            --allow-missing-secrets \
+            --api-versions monitoring.coreos.com/v1
+
+      - name: Comment on PR
+        if: ${{ github.event_name == 'pull_request' && always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo '## flate render diff'
+            echo ''
+            if [ -s diff.md ]; then
+              cat diff.md
+            else
+              echo '_No rendered resource changes detected._'
+            fi
+          } > comment.md
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --edit-last --create-if-none \
+            --body-file comment.md
+
+      - name: Clean up baseline worktree
+        if: always()
+        run: git worktree remove --force /tmp/flate-baseline || true

--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -6,7 +6,7 @@
       automerge: true,
       automergeType: "branch",
       matchUpdateTypes: ["minor", "patch", "pin", "digest"],
-      ignoreTests: true,
+      ignoreTests: false,
     },
     {
       description: "Auto-merge Helm chart updates as PRs for visibility",
@@ -23,6 +23,9 @@
       automergeType: "branch",
       matchUpdateTypes: ["minor", "patch", "digest"],
       minimumReleaseAge: "3 days",
+      // Out of scope for the flux-diff check (it only triggers on
+      // kubernetes/**/*.yaml paths) — leave ignoreTests true so these
+      // don't wait forever on a check that never runs.
       ignoreTests: true,
     },
     {
@@ -49,7 +52,7 @@
       matchUpdateTypes: ["digest"],
       automerge: true,
       automergeType: "branch",
-      ignoreTests: true,
+      ignoreTests: false,
     },
   ],
 }

--- a/kubernetes/apps/services/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/services/konflate/app/helmrelease.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app konflate
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: konflate
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"
+    config:
+      repo: github://j0sh3rs/home-ops
+      publicUrl: https://konflate.68cc.io
+      statusChecks: true
+      statusCheckName: Konflate
+      prComments: true
+    secret:
+      existingSecret: konflate-secrets
+    persistence:
+      enabled: true
+      storageClass: nfs-client
+      size: 5Gi
+    httpRoute:
+      enabled: true
+      hostnames: ["konflate.68cc.io"]
+      annotations:
+        external-dns.alpha.kubernetes.io/target: 192.168.35.15
+      parentRefs:
+        - name: traefik-external-gateway
+          namespace: network
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: authentik-forwardauth
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 1Gi

--- a/kubernetes/apps/services/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/services/konflate/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./secret.sops.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/services/konflate/app/ocirepository.yaml
+++ b/kubernetes/apps/services/konflate/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: konflate
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=ghcr.io/home-operations/charts/konflate
+    tag: 0.3.0
+  url: oci://ghcr.io/home-operations/charts/konflate

--- a/kubernetes/apps/services/konflate/app/secret.sops.yaml
+++ b/kubernetes/apps/services/konflate/app/secret.sops.yaml
@@ -1,0 +1,26 @@
+# PLACEHOLDER — replace KONFLATE_TOKEN with a real GitHub PAT (read-only,
+# `repo` scope on j0sh3rs/home-ops is sufficient), then encrypt IN PLACE:
+#   task sops:encrypt-file file=kubernetes/apps/services/konflate/app/secret.sops.yaml
+#   task sops:verify
+apiVersion: v1
+kind: Secret
+metadata:
+  name: konflate-secrets
+stringData:
+  KONFLATE_TOKEN: ENC[AES256_GCM,data:k9DK7rvkC6g=,iv:Lm4V5FvoJxU7ZwmHFxHOxDOqeCIHvG5aTTSsOUqeD+Y=,tag:Xod/qKRmgIfF2esKJyK1FA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpMVRKc081UUpKWXV0NTdt
+        bVlMRHRXQ1VFY1hvdnpVdUovUlJveENUekdjCnpVemRMYnEzTjk4Qno1elpZWGtv
+        dm5HTzRIanJ6QTJVeUJFcTNmYlZWMFEKLS0tIEtZeG1DWVFJNlNXWVVSNm5qeS91
+        cnRiUVd1WGpPdDVtWGpzcXBVRlo3MGcKR46enO5tuSiORVFT/DD9Q32Flk7AS/v0
+        q8d3MncR6GXtibcvi04mZjk6Flgqb7KYqVfnc/fms0D020jQ9Ih8bA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1qwwzsz6z2mmu6hpmjt2he7nepmnhutmhehvkva7l5zy5xzf08d5s5n4d6n
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-06T19:42:39Z"
+  mac: ENC[AES256_GCM,data:cQoIAsfDV1FpViRr8Mr6gBr3QsvgjJ93XH8SKrj04be4wWeZXnRWkFChz87giZ6VPXEzj3rndOFzjG2iP1rKE8WMzTLpBV5S002HcfqzNYhQJ+iH129rcWsyJ9HStNBmki40STjvskiCfgz/xIMObysLkQ1dIEVA4G2D7Yde25I=,iv:MdmbHepR5vhRmVsljRGBqpQfhEZUQUJUtfNjNuZm5B4=,tag:EZ+P+Q5khhGgCD2hntHfLw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/services/konflate/app/secret.sops.yaml
+++ b/kubernetes/apps/services/konflate/app/secret.sops.yaml
@@ -7,7 +7,7 @@ kind: Secret
 metadata:
   name: konflate-secrets
 stringData:
-  KONFLATE_TOKEN: ENC[AES256_GCM,data:k9DK7rvkC6g=,iv:Lm4V5FvoJxU7ZwmHFxHOxDOqeCIHvG5aTTSsOUqeD+Y=,tag:Xod/qKRmgIfF2esKJyK1FA==,type:str]
+  KONFLATE_TOKEN: ENC[AES256_GCM,data:l/wq3XWYpYASQ6Monoyvu/WAwuCcKN0xzS57aDrFj3V4WwVK+CPyhEKcnBy1VXujBN6CFqCUevvc3SrT3IQcpg==,iv:bfYowIalymKDj+05JBt/4vwTnmwCceKCDyujmihtFzk=,tag:+TQM4hgUaHOnLybC8rTwkg==,type:str]
 sops:
   age:
     - enc: |
@@ -20,7 +20,7 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age1qwwzsz6z2mmu6hpmjt2he7nepmnhutmhehvkva7l5zy5xzf08d5s5n4d6n
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-07-06T19:42:39Z"
-  mac: ENC[AES256_GCM,data:cQoIAsfDV1FpViRr8Mr6gBr3QsvgjJ93XH8SKrj04be4wWeZXnRWkFChz87giZ6VPXEzj3rndOFzjG2iP1rKE8WMzTLpBV5S002HcfqzNYhQJ+iH129rcWsyJ9HStNBmki40STjvskiCfgz/xIMObysLkQ1dIEVA4G2D7Yde25I=,iv:MdmbHepR5vhRmVsljRGBqpQfhEZUQUJUtfNjNuZm5B4=,tag:EZ+P+Q5khhGgCD2hntHfLw==,type:str]
+  lastmodified: "2026-07-06T21:36:31Z"
+  mac: ENC[AES256_GCM,data:0ytmTSolWoXV/uK4fDOb7TPYspX3Va+AjDPBDQ8TEuT5qhj7F1RDoDk0d6AiGHPX81LafmOyn+TbPfPRGzai4aKJJyvfTClj4scCzGyBCzhDGxiEtfddQEWRG4x9BzDONwq5PLXhOkLRKL2kCHyK1iWxcV4sR5R+WNBAyfpGdbs=,iv:PYd6ets8s51gShBMuki47RjM7XDBSjqIKcX0lwuU7Z8=,tag:qXnhvJLQMl+haFDeibN+fQ==,type:str]
   mac_only_encrypted: true
   version: 3.13.2

--- a/kubernetes/apps/services/konflate/ks.yaml
+++ b/kubernetes/apps/services/konflate/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app konflate
+  namespace: &namespace services
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/services/konflate/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/services/kustomization.yaml
+++ b/kubernetes/apps/services/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./homebridge/ks.yaml
   - ./homepage/ks.yaml
   - ./it-tools/ks.yaml
+  - ./konflate/ks.yaml
   - ./linkwarden/ks.yaml
   #  ./memos/ks.yaml
   - ./mosquitto/ks.yaml


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/flux-diff.yaml`: renders the Flux cluster offline with [flate](https://github.com/home-operations/flate) on every PR touching `kubernetes/**/*.yaml` (plus `push` on `renovate/**` branches, since Renovate's default automergeType merges branches without ever opening a PR). Posts the rendered-resource diff as a PR comment and fails the job on any reconcile error — that failure is what gates merge. Runs on `home-ops-runner`.
- Flips `ignoreTests: false` in `.renovate/autoMerge.json5` on the two rules whose diffs land under `kubernetes/**/*.yaml` (non-major auto-merge, CNPG digest rebuilds) so Renovate PRs actually wait on the new check. Left the GitHub Actions bump rule at `ignoreTests: true` — its diffs never touch `kubernetes/`, so the check would never fire and merges would hang forever.
- Deploys [konflate](https://github.com/home-operations/konflate) (evaluated per the issue) as a standing PR-review dashboard at `konflate.68cc.io`, behind Authentik forwardAuth, with write-back (status check + PR comments) enabled — the human-facing complement to the CI gate.

## Verification

Ran flate 0.4.10 locally against this repo (not just read the docs):

- `kustomize build kubernetes/apps/services/konflate/app` — clean.
- `task sops:verify` — passes, new secret encrypted.
- `flate test all --path ./kubernetes --allow-missing-secrets --api-versions monitoring.coreos.com/v1` — **184/184 pass**. Without `--api-versions monitoring.coreos.com/v1` this fails 2/184 on `main` itself (Traefik's `ServiceMonitor` template calls Helm's `Lookup` for a CRD flate doesn't install offline) — confirmed pre-existing by running the same command against a `main` worktree. Found this before it could silently block every future PR; the flag is baked into the workflow.
- `flate diff all --path ./kubernetes --path-orig <main-worktree>/kubernetes -o github` — correctly renders the new konflate `Kustomization`/`OCIRepository`/`HelmRelease`/`ServiceAccount`/`PersistentVolumeClaim` as additions, chart fetched live from `oci://ghcr.io/home-operations/charts/konflate`.

## Test plan

- [ ] Merge and confirm `flux-diff.yaml` runs on the next PR touching `kubernetes/`
- [ ] Confirm the "Konflate" commit status appears once the konflate `HelmRelease` reconciles and its `KONFLATE_TOKEN` secret is filled in (currently `CHANGEME` placeholder — needs a real read-only GitHub PAT, see `kubernetes/apps/services/konflate/app/secret.sops.yaml` header)
- [ ] Confirm `konflate.68cc.io` serves behind Authentik and lists open PRs
- [ ] Watch the next Renovate PR to confirm it waits on the "Flux Diff" check before auto-merging