### PR TITLE
feat(monitoring): add netdata system overview Grafana dashboard

### DIFF
--- a/kubernetes/apps/monitoring/netdata/app/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/netdata/app/grafanadashboard.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# Netdata system overview, sourced from the NAS's standalone netdata agent
+# (192.168.35.5), which pushes into vmsingle via a vmagent sidecar doing
+# Prometheus remote_write (job="netdata"). Not the in-cluster netdata
+# deployment above in this same app - that one streams to Netdata Cloud
+# directly and isn't scraped into vmsingle. Dashboard JSON verified against
+# this netdata instance's real /api/v1/allmetrics?format=prometheus output
+# before wiring in - metric names match exactly (netdata v2.10.4).
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: netdata-system-overview
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: vmsingle
+      inputName: DS_PROMETHEUS
+  url: https://raw.githubusercontent.com/AlexKutas/grafana-netdata-docker/main/netdata_system_overview_v1.json

--- a/kubernetes/apps/monitoring/netdata/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/netdata/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./secret.sops.yaml
   - ./helmrelease.yaml
+  - ./grafanadashboard.yaml


### PR DESCRIPTION
Sources from the NAS's standalone netdata agent (job="netdata" in vmsingle, via a vmagent sidecar). Verified the dashboard's expected metric names against that agent's real Prometheus output before wiring it in - no in-cluster netdata dashboard existed to reuse, and the grafana.com marketplace options (12279, 7107) are stale (2018/2020, predate netdata v2's metric naming).